### PR TITLE
utils return a result

### DIFF
--- a/modules/protocol/src/testing/utils.spec.ts
+++ b/modules/protocol/src/testing/utils.spec.ts
@@ -120,7 +120,9 @@ describe("utils", () => {
           channelFactoryAddress: networkContext.channelFactoryAddress,
         };
         // Run the test
-        const result = await generateSignedChannelCommitment(state, signer, update.aliceSignature, update.bobSignature);
+        const result = (
+          await generateSignedChannelCommitment(state, signer, update.aliceSignature, update.bobSignature)
+        ).getValue();
 
         const aliceSignature =
           expected.aliceSignature === "sig"

--- a/modules/protocol/src/update.ts
+++ b/modules/protocol/src/update.ts
@@ -318,7 +318,11 @@ export async function generateUpdate<T extends UpdateType>(
   }
 
   const { channel: updatedChannel, transfer: updatedTransfer } = result.getValue();
-  const commitment = await generateSignedChannelCommitment(updatedChannel, signer);
+  const commitmentRes = await generateSignedChannelCommitment(updatedChannel, signer);
+  if (commitmentRes.isError) {
+    return Result.fail(new OutboundChannelUpdateError(commitmentRes.getError()?.message as any, params, state));
+  }
+  const commitment = commitmentRes.getValue();
   logger.debug(
     {
       method: "generateUpdate",

--- a/modules/protocol/src/validate.ts
+++ b/modules/protocol/src/validate.ts
@@ -291,12 +291,16 @@ export async function validateAndApplyInboundUpdate<T extends UpdateType = any>(
   }
 
   // Generate the cosigned commitment
-  const signed = await generateSignedChannelCommitment(
+  const signedRes = await generateSignedChannelCommitment(
     nextState,
     signer,
     validUpdate.aliceSignature,
     validUpdate.bobSignature,
   );
+  if (signedRes.isError) {
+    return Result.fail(new InboundChannelUpdateError(signedRes.getError()?.message as any, validUpdate, nextState));
+  }
+  const signed = signedRes.getValue();
 
   // Add the signature to the state
   const signedNextState = {


### PR DESCRIPTION
## The Problem
Fixes #12 

- `generateSignedChannelCommitment` now returns a `Result` type like the other utility functions
