### PR TITLE
🚚 Rename from ServerNode

### DIFF
--- a/modules/browser-node/src/index.ts
+++ b/modules/browser-node/src/index.ts
@@ -13,8 +13,8 @@ import {
   NodeError,
   OptionalPublicIdentifier,
   Result,
-  ServerNodeParams,
-  ServerNodeResponses,
+  NodeParams,
+  NodeResponses,
 } from "@connext/vector-types";
 import { constructRpcRequest, hydrateProviders, NatsMessagingService } from "@connext/vector-utils";
 import { BaseLogger } from "pino";
@@ -73,13 +73,13 @@ export class BrowserNode implements INodeService {
     return this.engine.signerAddress;
   }
 
-  createNode(params: ServerNodeParams.CreateNode): Promise<Result<ServerNodeResponses.CreateNode, NodeError>> {
+  createNode(params: NodeParams.CreateNode): Promise<Result<NodeResponses.CreateNode, NodeError>> {
     return Promise.resolve(Result.fail(new NodeError(NodeError.reasons.MultinodeProhibitted, { params })));
   }
 
   async getStateChannelByParticipants(
-    params: OptionalPublicIdentifier<ServerNodeParams.GetChannelStateByParticipants>,
-  ): Promise<Result<ServerNodeResponses.GetChannelStateByParticipants, NodeError>> {
+    params: OptionalPublicIdentifier<NodeParams.GetChannelStateByParticipants>,
+  ): Promise<Result<NodeResponses.GetChannelStateByParticipants, NodeError>> {
     const rpc = constructRpcRequest(ChannelRpcMethods.chan_getChannelStateByParticipants, {
       alice: params.counterparty,
       bob: this.publicIdentifier,
@@ -94,8 +94,8 @@ export class BrowserNode implements INodeService {
   }
 
   async getStateChannel(
-    params: OptionalPublicIdentifier<ServerNodeParams.GetChannelState>,
-  ): Promise<Result<ServerNodeResponses.GetChannelState, NodeError>> {
+    params: OptionalPublicIdentifier<NodeParams.GetChannelState>,
+  ): Promise<Result<NodeResponses.GetChannelState, NodeError>> {
     const rpc = constructRpcRequest(ChannelRpcMethods.chan_getChannelState, params);
     try {
       const res = await this.engine.request<typeof ChannelRpcMethods.chan_getChannelState>(rpc);
@@ -105,7 +105,7 @@ export class BrowserNode implements INodeService {
     }
   }
 
-  async getStateChannels(): Promise<Result<ServerNodeResponses.GetChannelStates, NodeError>> {
+  async getStateChannels(): Promise<Result<NodeResponses.GetChannelStates, NodeError>> {
     const rpc = constructRpcRequest(ChannelRpcMethods.chan_getChannelStates, undefined);
     try {
       const res = await this.engine.request<typeof ChannelRpcMethods.chan_getChannelStates>(rpc);
@@ -116,8 +116,8 @@ export class BrowserNode implements INodeService {
   }
 
   async getTransferByRoutingId(
-    params: OptionalPublicIdentifier<ServerNodeParams.GetTransferStateByRoutingId>,
-  ): Promise<Result<ServerNodeResponses.GetTransferStateByRoutingId, NodeError>> {
+    params: OptionalPublicIdentifier<NodeParams.GetTransferStateByRoutingId>,
+  ): Promise<Result<NodeResponses.GetTransferStateByRoutingId, NodeError>> {
     const rpc = constructRpcRequest(ChannelRpcMethods.chan_getTransferStateByRoutingId, params);
     try {
       const res = await this.engine.request<typeof ChannelRpcMethods.chan_getTransferStateByRoutingId>(rpc);
@@ -128,20 +128,20 @@ export class BrowserNode implements INodeService {
   }
 
   async getTransfersByRoutingId(
-    params: OptionalPublicIdentifier<ServerNodeParams.GetTransferStatesByRoutingId>,
-  ): Promise<Result<ServerNodeResponses.GetTransferStatesByRoutingId, NodeError>> {
+    params: OptionalPublicIdentifier<NodeParams.GetTransferStatesByRoutingId>,
+  ): Promise<Result<NodeResponses.GetTransferStatesByRoutingId, NodeError>> {
     const rpc = constructRpcRequest(ChannelRpcMethods.chan_getTransferStatesByRoutingId, params);
     try {
       const res = await this.engine.request<typeof ChannelRpcMethods.chan_getTransferStatesByRoutingId>(rpc);
-      return Result.ok(res as ServerNodeResponses.GetTransferStatesByRoutingId);
+      return Result.ok(res as NodeResponses.GetTransferStatesByRoutingId);
     } catch (e) {
       return Result.fail(e);
     }
   }
 
   async getTransfer(
-    params: OptionalPublicIdentifier<ServerNodeParams.GetTransferState>,
-  ): Promise<Result<ServerNodeResponses.GetTransferState, NodeError>> {
+    params: OptionalPublicIdentifier<NodeParams.GetTransferState>,
+  ): Promise<Result<NodeResponses.GetTransferState, NodeError>> {
     const rpc = constructRpcRequest(ChannelRpcMethods.chan_getTransferState, params);
     try {
       const res = await this.engine.request<typeof ChannelRpcMethods.chan_getTransferState>(rpc);
@@ -152,8 +152,8 @@ export class BrowserNode implements INodeService {
   }
 
   async getActiveTransfers(
-    params: OptionalPublicIdentifier<ServerNodeParams.GetActiveTransfersByChannelAddress>,
-  ): Promise<Result<ServerNodeResponses.GetActiveTransfersByChannelAddress, NodeError>> {
+    params: OptionalPublicIdentifier<NodeParams.GetActiveTransfersByChannelAddress>,
+  ): Promise<Result<NodeResponses.GetActiveTransfersByChannelAddress, NodeError>> {
     const rpc = constructRpcRequest(ChannelRpcMethods.chan_getActiveTransfers, params);
     try {
       const res = await this.engine.request<typeof ChannelRpcMethods.chan_getActiveTransfers>(rpc);
@@ -164,8 +164,8 @@ export class BrowserNode implements INodeService {
   }
 
   async setup(
-    params: OptionalPublicIdentifier<ServerNodeParams.RequestSetup>,
-  ): Promise<Result<ServerNodeResponses.RequestSetup, NodeError>> {
+    params: OptionalPublicIdentifier<NodeParams.RequestSetup>,
+  ): Promise<Result<NodeResponses.RequestSetup, NodeError>> {
     const rpc = constructRpcRequest(ChannelRpcMethods.chan_requestSetup, params);
     try {
       const res = await this.engine.request<typeof ChannelRpcMethods.chan_requestSetup>(rpc);
@@ -176,18 +176,18 @@ export class BrowserNode implements INodeService {
   }
 
   // OK to leave unimplemented since browser node will never be Alice
-  async internalSetup(): Promise<Result<ServerNodeResponses.Setup, NodeError>> {
+  async internalSetup(): Promise<Result<NodeResponses.Setup, NodeError>> {
     throw new Error("Method not implemented");
   }
 
   // OK to leave unimplemented since all txes can be sent from outside the browser node
-  async sendDepositTx(): Promise<Result<ServerNodeResponses.SendDepositTx, NodeError>> {
+  async sendDepositTx(): Promise<Result<NodeResponses.SendDepositTx, NodeError>> {
     throw new Error("Method not implemented.");
   }
 
   async reconcileDeposit(
-    params: OptionalPublicIdentifier<ServerNodeParams.Deposit>,
-  ): Promise<Result<ServerNodeResponses.Deposit, NodeError>> {
+    params: OptionalPublicIdentifier<NodeParams.Deposit>,
+  ): Promise<Result<NodeResponses.Deposit, NodeError>> {
     const rpc = constructRpcRequest(ChannelRpcMethods.chan_deposit, params);
     try {
       const res = await this.engine.request<typeof ChannelRpcMethods.chan_deposit>(rpc);
@@ -198,8 +198,8 @@ export class BrowserNode implements INodeService {
   }
 
   async requestCollateral(
-    params: OptionalPublicIdentifier<ServerNodeParams.RequestCollateral>,
-  ): Promise<Result<ServerNodeResponses.RequestCollateral, NodeError>> {
+    params: OptionalPublicIdentifier<NodeParams.RequestCollateral>,
+  ): Promise<Result<NodeResponses.RequestCollateral, NodeError>> {
     const rpc = constructRpcRequest(ChannelRpcMethods.chan_requestCollateral, params);
     try {
       await this.engine.request<typeof ChannelRpcMethods.chan_requestCollateral>(rpc);
@@ -210,8 +210,8 @@ export class BrowserNode implements INodeService {
   }
 
   async conditionalTransfer(
-    params: OptionalPublicIdentifier<ServerNodeParams.ConditionalTransfer>,
-  ): Promise<Result<ServerNodeResponses.ConditionalTransfer, NodeError>> {
+    params: OptionalPublicIdentifier<NodeParams.ConditionalTransfer>,
+  ): Promise<Result<NodeResponses.ConditionalTransfer, NodeError>> {
     const rpc = constructRpcRequest(ChannelRpcMethods.chan_createTransfer, params);
     try {
       const res = await this.engine.request<typeof ChannelRpcMethods.chan_createTransfer>(rpc);
@@ -226,8 +226,8 @@ export class BrowserNode implements INodeService {
   }
 
   async resolveTransfer(
-    params: OptionalPublicIdentifier<ServerNodeParams.ResolveTransfer>,
-  ): Promise<Result<ServerNodeResponses.ResolveTransfer, NodeError>> {
+    params: OptionalPublicIdentifier<NodeParams.ResolveTransfer>,
+  ): Promise<Result<NodeResponses.ResolveTransfer, NodeError>> {
     const rpc = constructRpcRequest(ChannelRpcMethods.chan_resolveTransfer, params);
     try {
       const res = await this.engine.request<typeof ChannelRpcMethods.chan_resolveTransfer>(rpc);
@@ -242,8 +242,8 @@ export class BrowserNode implements INodeService {
   }
 
   async withdraw(
-    params: OptionalPublicIdentifier<ServerNodeParams.Withdraw>,
-  ): Promise<Result<ServerNodeResponses.Withdraw, NodeError>> {
+    params: OptionalPublicIdentifier<NodeParams.Withdraw>,
+  ): Promise<Result<NodeResponses.Withdraw, NodeError>> {
     const rpc = constructRpcRequest(ChannelRpcMethods.chan_withdraw, params);
     try {
       const res = await this.engine.request<typeof ChannelRpcMethods.chan_withdraw>(rpc);

--- a/modules/router/src/collateral.ts
+++ b/modules/router/src/collateral.ts
@@ -1,11 +1,4 @@
-import {
-  FullChannelState,
-  INodeService,
-  Result,
-  ServerNodeResponses,
-  Values,
-  VectorError,
-} from "@connext/vector-types";
+import { FullChannelState, INodeService, Result, NodeResponses, Values, VectorError } from "@connext/vector-types";
 import { getBalanceForAssetId } from "@connext/vector-utils";
 import { BigNumber } from "ethers";
 import { BaseLogger } from "pino";
@@ -43,7 +36,7 @@ export const requestCollateral = async (
   logger: BaseLogger,
   requestedAmount?: string,
   transferAmount?: string, // used when called internally
-): Promise<Result<undefined | ServerNodeResponses.Deposit, RequestCollateralError>> => {
+): Promise<Result<undefined | NodeResponses.Deposit, RequestCollateralError>> => {
   const profileRes = await getRebalanceProfile(channel.networkContext.chainId, assetId);
   if (profileRes.isError) {
     return Result.fail(
@@ -133,5 +126,5 @@ export const requestCollateral = async (
     );
   }
 
-  return depositRes as Result<ServerNodeResponses.Deposit>;
+  return depositRes as Result<NodeResponses.Deposit>;
 };

--- a/modules/router/src/forwarding.ts
+++ b/modules/router/src/forwarding.ts
@@ -2,11 +2,11 @@ import {
   ConditionalTransferCreatedPayload,
   ConditionalTransferResolvedPayload,
   Result,
-  ServerNodeResponses,
+  NodeResponses,
   Values,
   VectorError,
   RouterSchemas,
-  ServerNodeParams,
+  NodeParams,
   TRANSFER_DECREMENT,
   INodeService,
   NodeError,
@@ -15,7 +15,6 @@ import { BaseLogger } from "pino";
 import { BigNumber } from "ethers";
 
 import { getSwappedAmount } from "./services/swap";
-import { getRebalanceProfile } from "./services/rebalance";
 import { IRouterStore } from "./services/store";
 import { ChainJsonProviders } from "./listener";
 import { requestCollateral } from "./collateral";
@@ -261,7 +260,7 @@ export async function forwardTransferResolution(
   service: INodeService,
   store: IRouterStore,
   logger: BaseLogger,
-): Promise<Result<undefined | ServerNodeResponses.ResolveTransfer, ForwardResolutionError>> {
+): Promise<Result<undefined | NodeResponses.ResolveTransfer, ForwardResolutionError>> {
   const method = "forwardTransferResolution";
   logger.info(
     { data, method, node: { signerAddress, publicIdentifier } },
@@ -296,7 +295,7 @@ export async function forwardTransferResolution(
   }
 
   // Resolve the sender transfer
-  const resolveParams: ServerNodeParams.ResolveTransfer = {
+  const resolveParams: NodeParams.ResolveTransfer = {
     channelAddress: incomingTransfer.channelAddress,
     transferId: incomingTransfer.transferId,
     meta: {},

--- a/modules/server-node/examples/0-config.http
+++ b/modules/server-node/examples/0-config.http
@@ -20,11 +20,11 @@ GET {{carolUrl}}/config
 
 ##############
 ### GET CHANNELS
-GET {{aliceUrl}}/{{alicePublicIdentifier}}/channel
+GET {{aliceUrl}}/{{alicePublicIdentifier}}/channels
 
 ##############
 ### GET CHANNEL
-GET {{aliceUrl}}/{{alicePublicIdentifier}}/channel/{{aliceBobChannel}}
+GET {{aliceUrl}}/{{alicePublicIdentifier}}/channels/{{aliceBobChannel}}
 
 ##############
 ### GET CHANNEL BY PARTICIPANTS

--- a/modules/types/src/node.ts
+++ b/modules/types/src/node.ts
@@ -1,6 +1,6 @@
 import { EngineEvent, EngineEventMap } from "./engine";
 import { NodeError, Result } from "./error";
-import { ServerNodeParams, ServerNodeResponses } from "./schemas";
+import { NodeParams, NodeResponses } from "./schemas";
 
 // NOTE: This interface will also wrap server nodes that support a default
 // publicIdentifier (i.e. use a default index). This means that the interface
@@ -16,66 +16,62 @@ export interface INodeService {
   signerAddress: string;
 
   getStateChannelByParticipants(
-    params: OptionalPublicIdentifier<ServerNodeParams.GetChannelStateByParticipants>,
-  ): Promise<Result<ServerNodeResponses.GetChannelStateByParticipants, NodeError>>;
+    params: OptionalPublicIdentifier<NodeParams.GetChannelStateByParticipants>,
+  ): Promise<Result<NodeResponses.GetChannelStateByParticipants, NodeError>>;
 
   getStateChannels(
-    params: OptionalPublicIdentifier<ServerNodeParams.GetChannelStates>,
-  ): Promise<Result<ServerNodeResponses.GetChannelStates, NodeError>>;
+    params: OptionalPublicIdentifier<NodeParams.GetChannelStates>,
+  ): Promise<Result<NodeResponses.GetChannelStates, NodeError>>;
 
   getStateChannel(
-    params: OptionalPublicIdentifier<ServerNodeParams.GetChannelState>,
-  ): Promise<Result<ServerNodeResponses.GetChannelState, NodeError>>;
+    params: OptionalPublicIdentifier<NodeParams.GetChannelState>,
+  ): Promise<Result<NodeResponses.GetChannelState, NodeError>>;
 
   getTransferByRoutingId(
-    params: OptionalPublicIdentifier<ServerNodeParams.GetTransferStateByRoutingId>,
-  ): Promise<Result<ServerNodeResponses.GetTransferStateByRoutingId, NodeError>>;
+    params: OptionalPublicIdentifier<NodeParams.GetTransferStateByRoutingId>,
+  ): Promise<Result<NodeResponses.GetTransferStateByRoutingId, NodeError>>;
 
   getTransfersByRoutingId(
-    params: OptionalPublicIdentifier<ServerNodeParams.GetTransferStatesByRoutingId>,
-  ): Promise<Result<ServerNodeResponses.GetTransferStatesByRoutingId, NodeError>>;
+    params: OptionalPublicIdentifier<NodeParams.GetTransferStatesByRoutingId>,
+  ): Promise<Result<NodeResponses.GetTransferStatesByRoutingId, NodeError>>;
 
   getTransfer(
-    params: OptionalPublicIdentifier<ServerNodeParams.GetTransferState>,
-  ): Promise<Result<ServerNodeResponses.GetTransferState, NodeError>>;
+    params: OptionalPublicIdentifier<NodeParams.GetTransferState>,
+  ): Promise<Result<NodeResponses.GetTransferState, NodeError>>;
 
   getActiveTransfers(
-    params: OptionalPublicIdentifier<ServerNodeParams.GetActiveTransfersByChannelAddress>,
-  ): Promise<Result<ServerNodeResponses.GetActiveTransfersByChannelAddress, NodeError>>;
+    params: OptionalPublicIdentifier<NodeParams.GetActiveTransfersByChannelAddress>,
+  ): Promise<Result<NodeResponses.GetActiveTransfersByChannelAddress, NodeError>>;
 
-  createNode(params: ServerNodeParams.CreateNode): Promise<Result<ServerNodeResponses.CreateNode, NodeError>>;
+  createNode(params: NodeParams.CreateNode): Promise<Result<NodeResponses.CreateNode, NodeError>>;
 
   setup(
-    params: OptionalPublicIdentifier<ServerNodeParams.RequestSetup>,
-  ): Promise<Result<ServerNodeResponses.RequestSetup, NodeError>>;
+    params: OptionalPublicIdentifier<NodeParams.RequestSetup>,
+  ): Promise<Result<NodeResponses.RequestSetup, NodeError>>;
 
-  internalSetup(
-    params: OptionalPublicIdentifier<ServerNodeParams.Setup>,
-  ): Promise<Result<ServerNodeResponses.Setup, NodeError>>;
+  internalSetup(params: OptionalPublicIdentifier<NodeParams.Setup>): Promise<Result<NodeResponses.Setup, NodeError>>;
 
   sendDepositTx(
-    params: OptionalPublicIdentifier<ServerNodeParams.SendDepositTx>,
-  ): Promise<Result<ServerNodeResponses.SendDepositTx, NodeError>>;
+    params: OptionalPublicIdentifier<NodeParams.SendDepositTx>,
+  ): Promise<Result<NodeResponses.SendDepositTx, NodeError>>;
 
   reconcileDeposit(
-    params: OptionalPublicIdentifier<ServerNodeParams.Deposit>,
-  ): Promise<Result<ServerNodeResponses.Deposit, NodeError>>;
+    params: OptionalPublicIdentifier<NodeParams.Deposit>,
+  ): Promise<Result<NodeResponses.Deposit, NodeError>>;
 
   requestCollateral(
-    params: OptionalPublicIdentifier<ServerNodeParams.RequestCollateral>,
-  ): Promise<Result<ServerNodeResponses.RequestCollateral, NodeError>>;
+    params: OptionalPublicIdentifier<NodeParams.RequestCollateral>,
+  ): Promise<Result<NodeResponses.RequestCollateral, NodeError>>;
 
   conditionalTransfer(
-    params: OptionalPublicIdentifier<ServerNodeParams.ConditionalTransfer>,
-  ): Promise<Result<ServerNodeResponses.ConditionalTransfer, NodeError>>;
+    params: OptionalPublicIdentifier<NodeParams.ConditionalTransfer>,
+  ): Promise<Result<NodeResponses.ConditionalTransfer, NodeError>>;
 
   resolveTransfer(
-    params: OptionalPublicIdentifier<ServerNodeParams.ResolveTransfer>,
-  ): Promise<Result<ServerNodeResponses.ResolveTransfer, NodeError>>;
+    params: OptionalPublicIdentifier<NodeParams.ResolveTransfer>,
+  ): Promise<Result<NodeResponses.ResolveTransfer, NodeError>>;
 
-  withdraw(
-    params: OptionalPublicIdentifier<ServerNodeParams.Withdraw>,
-  ): Promise<Result<ServerNodeResponses.Withdraw, NodeError>>;
+  withdraw(params: OptionalPublicIdentifier<NodeParams.Withdraw>): Promise<Result<NodeResponses.Withdraw, NodeError>>;
 
   once<T extends EngineEvent>(
     event: T,

--- a/modules/types/src/schemas/index.ts
+++ b/modules/types/src/schemas/index.ts
@@ -3,4 +3,4 @@ export * from "./config";
 export * from "./engine";
 export * from "./protocol";
 export * from "./router";
-export * from "./serverNode";
+export * from "./node";

--- a/modules/types/src/schemas/node.ts
+++ b/modules/types/src/schemas/node.ts
@@ -12,7 +12,6 @@ import {
   TFullTransferState,
   TFullChannelState,
   TChainId,
-  TBasicMeta,
 } from "./basic";
 
 ////////////////////////////////////////
@@ -255,7 +254,7 @@ const PostAdminResponseSchema = {
 
 // Namespace exports
 // eslint-disable-next-line @typescript-eslint/no-namespace
-export namespace ServerNodeParams {
+export namespace NodeParams {
   export const GetTransferStateByRoutingIdSchema = GetTransferStateByRoutingIdParamsSchema;
   export type GetTransferStateByRoutingId = Static<typeof GetTransferStateByRoutingIdParamsSchema>;
 
@@ -321,7 +320,7 @@ export namespace ServerNodeParams {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
-export namespace ServerNodeResponses {
+export namespace NodeResponses {
   export const GetTransferStateByRoutingIdSchema = GetTransferStateByRoutingIdResponseSchema;
   export type GetTransferStateByRoutingId = Static<typeof GetTransferStateByRoutingIdResponseSchema["200"]>;
 

--- a/modules/utils/src/serverNode.ts
+++ b/modules/utils/src/serverNode.ts
@@ -3,8 +3,8 @@ import {
   EngineEventMap,
   INodeService,
   Result,
-  ServerNodeParams,
-  ServerNodeResponses,
+  NodeParams,
+  NodeResponses,
   NodeError,
   OptionalPublicIdentifier,
 } from "@connext/vector-types";
@@ -63,16 +63,16 @@ export class RestServerNodeService implements INodeService {
     return service;
   }
 
-  async getConfig(): Promise<Result<ServerNodeResponses.GetConfig, NodeError>> {
-    return this.executeHttpRequest("config", "get", {}, ServerNodeParams.GetConfigSchema);
+  async getConfig(): Promise<Result<NodeResponses.GetConfig, NodeError>> {
+    return this.executeHttpRequest("config", "get", {}, NodeParams.GetConfigSchema);
   }
 
-  async createNode(params: ServerNodeParams.CreateNode): Promise<Result<ServerNodeResponses.CreateNode, NodeError>> {
-    const res = await this.executeHttpRequest<ServerNodeResponses.CreateNode>(
+  async createNode(params: NodeParams.CreateNode): Promise<Result<NodeResponses.CreateNode, NodeError>> {
+    const res = await this.executeHttpRequest<NodeResponses.CreateNode>(
       `node`,
       "post",
       params,
-      ServerNodeParams.CreateNodeSchema,
+      NodeParams.CreateNodeSchema,
     );
     if (res.isError) {
       return res;
@@ -87,7 +87,7 @@ export class RestServerNodeService implements INodeService {
       // Create an evt context for this public identifier only
       // (see not in `off`)
       this.ctxs[publicIdentifier] = Evt.newCtx();
-      const params: ServerNodeParams.RegisterListener = {
+      const params: NodeParams.RegisterListener = {
         events: urls,
         publicIdentifier: publicIdentifier ?? this.publicIdentifier,
       };
@@ -97,7 +97,7 @@ export class RestServerNodeService implements INodeService {
         `event/subscribe`,
         "post",
         params,
-        ServerNodeParams.RegisterListenerSchema,
+        NodeParams.RegisterListenerSchema,
       );
       if (subscription.isError) {
         this.logger.error({ error: subscription.getError()! }, "Failed to create subscription");
@@ -109,123 +109,113 @@ export class RestServerNodeService implements INodeService {
   }
 
   async getStateChannel(
-    params: OptionalPublicIdentifier<ServerNodeParams.GetChannelState>,
-  ): Promise<Result<ServerNodeResponses.GetChannelState, NodeError>> {
+    params: OptionalPublicIdentifier<NodeParams.GetChannelState>,
+  ): Promise<Result<NodeResponses.GetChannelState, NodeError>> {
     return this.executeHttpRequest(
       `${params.publicIdentifier ?? this.publicIdentifier}/channels/${params.channelAddress}`,
       "get",
       params,
-      ServerNodeParams.GetChannelStateSchema,
+      NodeParams.GetChannelStateSchema,
     );
   }
 
   async getStateChannels(
-    params: OptionalPublicIdentifier<ServerNodeParams.GetChannelStates>,
-  ): Promise<Result<ServerNodeResponses.GetChannelStates, NodeError>> {
+    params: OptionalPublicIdentifier<NodeParams.GetChannelStates>,
+  ): Promise<Result<NodeResponses.GetChannelStates, NodeError>> {
     return this.executeHttpRequest(
       `${params.publicIdentifier ?? this.publicIdentifier}/channels`,
       "get",
       params,
-      ServerNodeParams.GetChannelStatesSchema,
+      NodeParams.GetChannelStatesSchema,
     );
   }
 
   async getTransfersByRoutingId(
-    params: OptionalPublicIdentifier<ServerNodeParams.GetTransferStatesByRoutingId>,
-  ): Promise<Result<ServerNodeResponses.GetTransferStatesByRoutingId, NodeError>> {
+    params: OptionalPublicIdentifier<NodeParams.GetTransferStatesByRoutingId>,
+  ): Promise<Result<NodeResponses.GetTransferStatesByRoutingId, NodeError>> {
     return this.executeHttpRequest(
       `${params.publicIdentifier ?? this.publicIdentifier}/transfers/routing-id/${params.routingId}`,
       "get",
       params,
-      ServerNodeParams.GetTransferStatesByRoutingIdSchema,
+      NodeParams.GetTransferStatesByRoutingIdSchema,
     );
   }
 
   async getTransferByRoutingId(
-    params: OptionalPublicIdentifier<ServerNodeParams.GetTransferStateByRoutingId>,
-  ): Promise<Result<ServerNodeResponses.GetTransferStateByRoutingId, NodeError>> {
+    params: OptionalPublicIdentifier<NodeParams.GetTransferStateByRoutingId>,
+  ): Promise<Result<NodeResponses.GetTransferStateByRoutingId, NodeError>> {
     return this.executeHttpRequest(
       `${params.publicIdentifier ?? this.publicIdentifier}/channels/${params.channelAddress}/transfers/routing-id/${
         params.routingId
       }`,
       "get",
       params,
-      ServerNodeParams.GetTransferStateByRoutingIdSchema,
+      NodeParams.GetTransferStateByRoutingIdSchema,
     );
   }
 
   async getTransfer(
-    params: OptionalPublicIdentifier<ServerNodeParams.GetTransferState>,
-  ): Promise<Result<ServerNodeResponses.GetTransferState, NodeError>> {
+    params: OptionalPublicIdentifier<NodeParams.GetTransferState>,
+  ): Promise<Result<NodeResponses.GetTransferState, NodeError>> {
     return this.executeHttpRequest(
       `${params.publicIdentifier ?? this.publicIdentifier}/transfers/${params.transferId}`,
       "get",
       params,
-      ServerNodeParams.GetTransferStateSchema,
+      NodeParams.GetTransferStateSchema,
     );
   }
 
   async getActiveTransfers(
-    params: OptionalPublicIdentifier<ServerNodeParams.GetActiveTransfersByChannelAddress>,
-  ): Promise<Result<ServerNodeResponses.GetActiveTransfersByChannelAddress, NodeError>> {
+    params: OptionalPublicIdentifier<NodeParams.GetActiveTransfersByChannelAddress>,
+  ): Promise<Result<NodeResponses.GetActiveTransfersByChannelAddress, NodeError>> {
     return this.executeHttpRequest(
       `${params.publicIdentifier ?? this.publicIdentifier}/channels/${params.channelAddress}/active-transfers`,
       "get",
       params,
-      ServerNodeParams.GetActiveTransfersByChannelAddressSchema,
+      NodeParams.GetActiveTransfersByChannelAddressSchema,
     );
   }
 
   async getStateChannelByParticipants(
-    params: OptionalPublicIdentifier<ServerNodeParams.GetChannelStateByParticipants>,
-  ): Promise<Result<ServerNodeResponses.GetChannelStateByParticipants, NodeError>> {
+    params: OptionalPublicIdentifier<NodeParams.GetChannelStateByParticipants>,
+  ): Promise<Result<NodeResponses.GetChannelStateByParticipants, NodeError>> {
     return this.executeHttpRequest(
       `${params.publicIdentifier ?? this.publicIdentifier}/channels/counterparty/${params.counterparty}/chain-id/${
         params.chainId
       }`,
       "get",
       params,
-      ServerNodeParams.GetChannelStateByParticipantsSchema,
+      NodeParams.GetChannelStateByParticipantsSchema,
     );
   }
 
   async setup(
-    params: OptionalPublicIdentifier<ServerNodeParams.RequestSetup>,
-  ): Promise<Result<ServerNodeResponses.RequestSetup, NodeError>> {
-    return this.executeHttpRequest<ServerNodeResponses.RequestSetup>(
-      "setup",
-      "post",
-      params,
-      ServerNodeParams.RequestSetupSchema,
-    );
+    params: OptionalPublicIdentifier<NodeParams.RequestSetup>,
+  ): Promise<Result<NodeResponses.RequestSetup, NodeError>> {
+    return this.executeHttpRequest<NodeResponses.RequestSetup>("setup", "post", params, NodeParams.RequestSetupSchema);
   }
 
   async internalSetup(
-    params: OptionalPublicIdentifier<ServerNodeParams.Setup>,
-  ): Promise<Result<ServerNodeResponses.Setup, NodeError>> {
-    return this.executeHttpRequest<ServerNodeResponses.Setup>(
-      "internal-setup",
-      "post",
-      params,
-      ServerNodeParams.SetupSchema,
-    );
+    params: OptionalPublicIdentifier<NodeParams.Setup>,
+  ): Promise<Result<NodeResponses.Setup, NodeError>> {
+    return this.executeHttpRequest<NodeResponses.Setup>("internal-setup", "post", params, NodeParams.SetupSchema);
   }
 
   async sendDepositTx(
-    params: OptionalPublicIdentifier<ServerNodeParams.SendDepositTx>,
-  ): Promise<Result<ServerNodeResponses.SendDepositTx, NodeError>> {
-    return this.executeHttpRequest<ServerNodeResponses.SendDepositTx>(
+    params: OptionalPublicIdentifier<NodeParams.SendDepositTx>,
+  ): Promise<Result<NodeResponses.SendDepositTx, NodeError>> {
+    return this.executeHttpRequest<NodeResponses.SendDepositTx>(
       "send-deposit-tx",
       "post",
       params,
-      ServerNodeParams.SendDepositTxSchema,
+      NodeParams.SendDepositTxSchema,
     );
   }
 
   async reconcileDeposit(
-    params: OptionalPublicIdentifier<ServerNodeParams.Deposit>,
-  ): Promise<Result<ServerNodeResponses.Deposit, NodeError>> {
-    return this.executeHttpRequest<ServerNodeResponses.Deposit>(
+    params: OptionalPublicIdentifier<NodeParams.Deposit>,
+  ): Promise<Result<NodeResponses.Deposit, NodeError>> {
+    return this.executeHttpRequest<NodeResponses.Deposit>(
       "deposit",
       "post",
       {
@@ -233,52 +223,47 @@ export class RestServerNodeService implements INodeService {
         assetId: params.assetId,
         publicIdentifier: params.publicIdentifier,
       },
-      ServerNodeParams.DepositSchema,
+      NodeParams.DepositSchema,
     );
   }
 
   async requestCollateral(
-    params: OptionalPublicIdentifier<ServerNodeParams.RequestCollateral>,
-  ): Promise<Result<ServerNodeResponses.RequestCollateral, NodeError>> {
-    return this.executeHttpRequest<ServerNodeResponses.RequestCollateral>(
+    params: OptionalPublicIdentifier<NodeParams.RequestCollateral>,
+  ): Promise<Result<NodeResponses.RequestCollateral, NodeError>> {
+    return this.executeHttpRequest<NodeResponses.RequestCollateral>(
       "request-collateral",
       "post",
       params,
-      ServerNodeParams.RequestCollateralSchema,
+      NodeParams.RequestCollateralSchema,
     );
   }
 
   async conditionalTransfer(
-    params: OptionalPublicIdentifier<ServerNodeParams.ConditionalTransfer>,
-  ): Promise<Result<ServerNodeResponses.ConditionalTransfer, NodeError>> {
-    return this.executeHttpRequest<ServerNodeResponses.ConditionalTransfer>(
+    params: OptionalPublicIdentifier<NodeParams.ConditionalTransfer>,
+  ): Promise<Result<NodeResponses.ConditionalTransfer, NodeError>> {
+    return this.executeHttpRequest<NodeResponses.ConditionalTransfer>(
       `transfers/create`,
       "post",
       params,
-      ServerNodeParams.ConditionalTransferSchema,
+      NodeParams.ConditionalTransferSchema,
     );
   }
 
   async resolveTransfer(
-    params: OptionalPublicIdentifier<ServerNodeParams.ResolveTransfer>,
-  ): Promise<Result<ServerNodeResponses.ResolveTransfer, NodeError>> {
-    return this.executeHttpRequest<ServerNodeResponses.ResolveTransfer>(
+    params: OptionalPublicIdentifier<NodeParams.ResolveTransfer>,
+  ): Promise<Result<NodeResponses.ResolveTransfer, NodeError>> {
+    return this.executeHttpRequest<NodeResponses.ResolveTransfer>(
       `transfers/resolve`,
       "post",
       params,
-      ServerNodeParams.ResolveTransferSchema,
+      NodeParams.ResolveTransferSchema,
     );
   }
 
   async withdraw(
-    params: OptionalPublicIdentifier<ServerNodeParams.Withdraw>,
-  ): Promise<Result<ServerNodeResponses.Withdraw, NodeError>> {
-    return this.executeHttpRequest<ServerNodeResponses.Withdraw>(
-      `withdraw`,
-      "post",
-      params,
-      ServerNodeParams.WithdrawSchema,
-    );
+    params: OptionalPublicIdentifier<NodeParams.Withdraw>,
+  ): Promise<Result<NodeResponses.Withdraw, NodeError>> {
+    return this.executeHttpRequest<NodeResponses.Withdraw>(`withdraw`, "post", params, NodeParams.WithdrawSchema);
   }
 
   public once<T extends EngineEvent>(


### PR DESCRIPTION
## The Problem
<!--- Why is this change required? What problem does it solve? Bug fix or new feature? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Resolves #135 and #88 

## The Solution
<!--- Describe the changes you made at a high level -->
<!--- Leave comments on the source diff to draw attention to important low-level specifics -->
- Rename ServerNode{Params,Responses} to Node{Params,Responses}
- Filter `getChannelStates` query result by publicIdentifier
