### PR TITLE
Transfer definitions and transfer registry changes

### DIFF
--- a/modules/contracts/src.sol/TransferRegistry.sol
+++ b/modules/contracts/src.sol/TransferRegistry.sol
@@ -5,6 +5,7 @@ pragma experimental ABIEncoderV2;
 import "./interfaces/ITransferRegistry.sol";
 import "./interfaces/Types.sol";
 import "./lib/LibIterableMapping.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
 
 /// @title TransferRegistry
 /// @author Layne Haber <layne@connext.network>
@@ -14,22 +15,11 @@ import "./lib/LibIterableMapping.sol";
 ///         this information to get the correct encodings when generating
 ///         signatures. The information stored here can only be updated
 ///         by the owner of the contract
-contract TransferRegistry is ITransferRegistry {
+contract TransferRegistry is Ownable, ITransferRegistry {
 
   using LibIterableMapping for LibIterableMapping.IterableMapping;
 
-  address immutable owner;
-
   LibIterableMapping.IterableMapping transfers;
-
-  constructor() {
-    owner = msg.sender;
-  }
-
-  modifier onlyOwner() {
-    require(msg.sender == owner, "Only owner can call function");
-    _;
-  }
 
   // Should add a transfer definition to the registry
   // onlyOwner

--- a/modules/contracts/src.sol/interfaces/ITransferDefinition.sol
+++ b/modules/contracts/src.sol/interfaces/ITransferDefinition.sol
@@ -17,12 +17,15 @@ interface ITransferDefinition {
     bytes calldata
   ) external view returns (Balance memory);
 
-  // Should also have the following properties
-  // string name
-  // string stateEncoding
-  // string resolverEncoding
+  // Should also have the following properties:
+  // string public constant override Name = "...";
+  // string public constant override StateEncoding = "...";
+  // string public constant override ResolverEncoding = "...";
   // These properties are included on the transfer specifically
   // to make it easier for implementers to add new transfers by
   // only include a `.sol` file
+  function Name() external view returns (string memory);
+  function StateEncoding() external view returns (string memory);
+  function ResolverEncoding() external view returns (string memory);
   function getRegistryInformation() external view returns (RegisteredTransfer memory);
 }

--- a/modules/contracts/src.sol/interfaces/ITransferDefinition.sol
+++ b/modules/contracts/src.sol/interfaces/ITransferDefinition.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.7.1;
-pragma experimental "ABIEncoderV2";
+pragma experimental ABIEncoderV2;
 
 import "./Types.sol";
 

--- a/modules/contracts/src.sol/transferDefinitions/HashlockTransfer.sol
+++ b/modules/contracts/src.sol/transferDefinitions/HashlockTransfer.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.7.1;
-pragma experimental "ABIEncoderV2";
+pragma experimental ABIEncoderV2;
 
 import "../interfaces/ITransferDefinition.sol";
 

--- a/modules/contracts/src.sol/transferDefinitions/HashlockTransfer.sol
+++ b/modules/contracts/src.sol/transferDefinitions/HashlockTransfer.sol
@@ -41,7 +41,7 @@ contract HashlockTransfer is ITransferDefinition {
 
     require(balance.amount[1] == 0, "Cannot create hashlock transfer with nonzero recipient balance");
     require(state.lockHash != bytes32(0), "Cannot create hashlock transfer with empty lockHash");
-    require(state.expiry > block.number || state.expiry == 0, "Cannot create hashlock transfer with expired timelock");
+    require(state.expiry == 0 || state.expiry > block.number, "Cannot create hashlock transfer with expired timelock");
     return true;
   }
 
@@ -56,7 +56,7 @@ contract HashlockTransfer is ITransferDefinition {
 
     // If you pass in bytes32(0), payment is canceled
     // If timelock is nonzero and has expired, payment is canceled
-    if (resolver.preImage != bytes32(0) && (state.expiry > block.number || state.expiry == 0)) {
+    if (resolver.preImage != bytes32(0) && (state.expiry == 0 || state.expiry > block.number)) {
       // Check hash for normal payment unlock
       bytes32 generatedHash = sha256(abi.encode(resolver.preImage));
       require(state.lockHash == generatedHash, "Hash generated from preimage does not match hash in state");

--- a/modules/contracts/src.sol/transferDefinitions/HashlockTransfer.sol
+++ b/modules/contracts/src.sol/transferDefinitions/HashlockTransfer.sol
@@ -2,14 +2,14 @@
 pragma solidity ^0.7.1;
 pragma experimental ABIEncoderV2;
 
-import "../interfaces/ITransferDefinition.sol";
+import "./TransferDefinition.sol";
 
 /// @title Hashlock Transfer
 /// @notice This contract allows users to claim a payment locked in
 ///         the application if they provide the correct preImage. The payment is
 ///         reverted if not unlocked by the timelock if one is provided.
 
-contract HashlockTransfer is ITransferDefinition {
+contract HashlockTransfer is TransferDefinition {
   struct TransferState {
     bytes32 lockHash;
     uint256 expiry; // If 0, then no timelock is enforced
@@ -19,21 +19,9 @@ contract HashlockTransfer is ITransferDefinition {
     bytes32 preImage;
   }
 
-  string StateEncoding = "tuple(bytes32 lockHash, uint256 expiry)";
-
-  string ResolverEncoding = "tuple(bytes32 preImage)";
-
-  string Name = "HashlockTransfer";
-
-  function getRegistryInformation() external override view returns (RegisteredTransfer memory) {
-    RegisteredTransfer memory info = RegisteredTransfer({
-      name: Name,
-      stateEncoding: StateEncoding,
-      resolverEncoding: ResolverEncoding,
-      definition: address(this)
-    });
-    return info;
-  }
+  string public constant override Name = "HashlockTransfer";
+  string public constant override StateEncoding = "tuple(bytes32 lockHash, uint256 expiry)";
+  string public constant override ResolverEncoding = "tuple(bytes32 preImage)";
 
   function create(bytes calldata encodedBalance, bytes calldata encodedState) external override view returns (bool) {
     TransferState memory state = abi.decode(encodedState, (TransferState));

--- a/modules/contracts/src.sol/transferDefinitions/TransferDefinition.sol
+++ b/modules/contracts/src.sol/transferDefinitions/TransferDefinition.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.7.1;
+pragma experimental ABIEncoderV2;
+
+import "../interfaces/ITransferDefinition.sol";
+
+abstract contract TransferDefinition is ITransferDefinition {
+
+  function getRegistryInformation() external override view returns (RegisteredTransfer memory) {
+    return RegisteredTransfer({
+      name: this.Name(),
+      stateEncoding: this.StateEncoding(),
+      resolverEncoding: this.ResolverEncoding(),
+      definition: address(this)
+    });
+  }
+
+}

--- a/modules/contracts/src.sol/transferDefinitions/Withdraw.sol
+++ b/modules/contracts/src.sol/transferDefinitions/Withdraw.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.7.1;
-pragma experimental "ABIEncoderV2";
+pragma experimental ABIEncoderV2;
 
 import "../interfaces/ITransferDefinition.sol";
 import "../lib/LibChannelCrypto.sol";

--- a/modules/contracts/src.sol/transferDefinitions/Withdraw.sol
+++ b/modules/contracts/src.sol/transferDefinitions/Withdraw.sol
@@ -2,14 +2,14 @@
 pragma solidity ^0.7.1;
 pragma experimental ABIEncoderV2;
 
-import "../interfaces/ITransferDefinition.sol";
+import "./TransferDefinition.sol";
 import "../lib/LibChannelCrypto.sol";
 
 /// @title Withdraw
 /// @notice This contract burns the initiator's funds if a mutually signed
 ///         withdraw commitment can be generated
 
-contract Withdraw is ITransferDefinition {
+contract Withdraw is TransferDefinition {
   using LibChannelCrypto for bytes32;
 
   struct TransferState {
@@ -25,21 +25,9 @@ contract Withdraw is ITransferDefinition {
     bytes responderSignature;
   }
 
-  string StateEncoding = "tuple(bytes initiatorSignature, address initiator, address responder, bytes32 data, uint256 nonce, uint256 fee)";
-
-  string ResolverEncoding = "tuple(bytes responderSignature)";
-
-  string Name = "Withdraw";
-
-  function getRegistryInformation() external override view returns (RegisteredTransfer memory) {
-    RegisteredTransfer memory info = RegisteredTransfer({
-      name: Name,
-      stateEncoding: StateEncoding,
-      resolverEncoding: ResolverEncoding,
-      definition: address(this)
-    });
-    return info;
-  }
+  string public constant override Name = "Withdraw";
+  string public constant override StateEncoding = "tuple(bytes initiatorSignature, address initiator, address responder, bytes32 data, uint256 nonce, uint256 fee)";
+  string public constant override ResolverEncoding = "tuple(bytes responderSignature)";
 
   function create(bytes calldata encodedBalance, bytes calldata encodedState) external override pure returns (bool) {
     TransferState memory state = abi.decode(encodedState, (TransferState));

--- a/modules/contracts/src.ts/tests/transferRegistry.spec.ts
+++ b/modules/contracts/src.ts/tests/transferRegistry.spec.ts
@@ -36,7 +36,7 @@ describe("TransferRegistry.sol", () => {
 
     it("should fail IFF not called by the owner", async () => {
       await expect(registry.connect(rando).addTransferDefinition(registryInfo)).revertedWith(
-        "Only owner can call function",
+        "Ownable: caller is not the owner",
       );
     });
   });
@@ -52,7 +52,7 @@ describe("TransferRegistry.sol", () => {
 
     it("should fail IFF not called by the owner", async () => {
       await expect(registry.connect(rando).removeTransferDefinition(transfer.address)).revertedWith(
-        "Only owner can call function",
+        "Ownable: caller is not the owner",
       );
     });
   });

--- a/modules/documentation/docs/changelog.md
+++ b/modules/documentation/docs/changelog.md
@@ -5,6 +5,7 @@
 - fix `defundNonce` in server node store
 - expose nats 4221 by default
 - improve asset handling
+- minor changes in transfer definitions and transfer registry
 
 ## @connext/{types,utils,contracts,protocol,engine,browser-node}@0.0.4
 


### PR DESCRIPTION
A few minor changes:
* make `HashlockTransfer` work with pure-evm for expiry 0
* reduce boilerplate in transfer definitions
* use OpenZeppelin's `Ownable`