### PR TITLE
fix: initiator cannot be receiver on same chain.

### DIFF
--- a/modules/engine/src/paramConverter.ts
+++ b/modules/engine/src/paramConverter.ts
@@ -37,7 +37,7 @@ export async function convertConditionalTransferParams(
   // TODO: Compare recipientChainId with signerChainId
   if (recipient === signer.publicIdentifier) {
     // If signer is also the receipient on same chain/network
-    throw new Error(`Invalid initiator cannot be receiver on same chain`);
+    return Result.fail(new InvalidTransferType("self: an initiator cannot be a receiver on the same chain"));
   }
 
   // If the recipient is the channel counterparty, no default routing

--- a/modules/engine/src/paramConverter.ts
+++ b/modules/engine/src/paramConverter.ts
@@ -34,10 +34,9 @@ export async function convertConditionalTransferParams(
   const recipientAssetId = params.recipientAssetId ?? params.assetId;
   const channelCounterparty = signer.address === channel.alice ? channel.bob : channel.alice;
 
-  // TODO: Compare recipientChainId with signerChainId
-  if (recipient === signer.publicIdentifier) {
+  if (recipient === signer.publicIdentifier && recipientChainId === channel.networkContext.chainId) {
     // If signer is also the receipient on same chain/network
-    return Result.fail(new InvalidTransferType("self: an initiator cannot be a receiver on the same chain"));
+    return Result.fail(new InvalidTransferType("An initiator cannot be a receiver on the same chain"));
   }
 
   // If the recipient is the channel counterparty, no default routing

--- a/modules/engine/src/paramConverter.ts
+++ b/modules/engine/src/paramConverter.ts
@@ -34,6 +34,12 @@ export async function convertConditionalTransferParams(
   const recipientAssetId = params.recipientAssetId ?? params.assetId;
   const channelCounterparty = signer.address === channel.alice ? channel.bob : channel.alice;
 
+  // TODO: Compare recipientChainId with signerChainId
+  if (recipient === signer.publicIdentifier) {
+    // If signer is also the receipient on same chain/network
+    throw new Error(`Invalid initiator cannot be receiver on same chain`);
+  }
+
   // If the recipient is the channel counterparty, no default routing
   // meta needs to be created, otherwise create the default routing meta.
   // NOTE: While the engine and protocol do not care about the structure
@@ -113,11 +119,7 @@ export async function convertWithdrawParams(
   const { channelAddress, assetId, recipient, fee, callTo, callData } = params;
 
   // If there is a fee being charged, add the fee to the amount.
-  const amount = fee
-    ? BigNumber.from(params.amount)
-        .add(fee)
-        .toString()
-    : params.amount;
+  const amount = fee ? BigNumber.from(params.amount).add(fee).toString() : params.amount;
 
   const commitment = new WithdrawCommitment(
     channel.channelAddress,

--- a/modules/engine/src/paramConverter.ts
+++ b/modules/engine/src/paramConverter.ts
@@ -27,7 +27,7 @@ export async function convertConditionalTransferParams(
   channel: FullChannelState,
   chainAddresses: ChainAddresses,
   chainReader: IVectorChainReader,
-): Promise<Result<CreateTransferParams, InvalidTransferType>> {
+): Promise<Result<CreateTransferParams, InvalidTransferType | Error>> {
   const { channelAddress, amount, assetId, recipient, details, type, timeout, meta: providedMeta } = params;
 
   const recipientChainId = params.recipientChainId ?? channel.networkContext.chainId;
@@ -36,7 +36,7 @@ export async function convertConditionalTransferParams(
 
   if (recipient === signer.publicIdentifier && recipientChainId === channel.networkContext.chainId) {
     // If signer is also the receipient on same chain/network
-    return Result.fail(new InvalidTransferType("An initiator cannot be a receiver on the same chain"));
+    return Result.fail(new Error("An initiator cannot be a receiver on the same chain"));
   }
 
   // If the recipient is the channel counterparty, no default routing

--- a/modules/engine/src/testing/paramConverter.spec.ts
+++ b/modules/engine/src/testing/paramConverter.spec.ts
@@ -37,6 +37,8 @@ import {
 import { env } from "./env";
 
 describe("ParamConverter", () => {
+  it.skip("should fail if initiator is receiver for same chain/network");
+
   const chainId = parseInt(Object.keys(env.chainProviders)[0]);
   const providerUrl = env.chainProviders[chainId];
   const signerA = getRandomChannelSigner(providerUrl);
@@ -282,12 +284,7 @@ describe("ParamConverter", () => {
       expect(ret).to.deep.eq({
         channelAddress: channelState.channelAddress,
         balance: {
-          amount: [
-            BigNumber.from(params.amount)
-              .add(params.fee)
-              .toString(),
-            "0",
-          ],
+          amount: [BigNumber.from(params.amount).add(params.fee).toString(), "0"],
           to: [params.recipient, channelState.bob],
         },
         assetId: params.assetId,
@@ -328,12 +325,7 @@ describe("ParamConverter", () => {
       expect(ret).to.deep.eq({
         channelAddress: channelState.channelAddress,
         balance: {
-          amount: [
-            BigNumber.from(params.amount)
-              .add(params.fee)
-              .toString(),
-            "0",
-          ],
+          amount: [BigNumber.from(params.amount).add(params.fee).toString(), "0"],
           to: [params.recipient, channelState.alice],
         },
         assetId: params.assetId,

--- a/modules/engine/src/testing/paramConverter.spec.ts
+++ b/modules/engine/src/testing/paramConverter.spec.ts
@@ -37,8 +37,6 @@ import {
 import { env } from "./env";
 
 describe("ParamConverter", () => {
-  it.skip("should fail if initiator is receiver for same chain/network");
-
   const chainId = parseInt(Object.keys(env.chainProviders)[0]);
   const providerUrl = env.chainProviders[chainId];
   const signerA = getRandomChannelSigner(providerUrl);
@@ -78,7 +76,7 @@ describe("ParamConverter", () => {
       chainReader.getRegisteredTransferByDefinition.resolves(Result.ok<RegisteredTransfer>(transferRegisteredInfo));
     });
 
-    const generateParams = (bIsRecipient = false): EngineParams.ConditionalTransfer => {
+    const generateParams = (bIsRecipient = false, receipientChainId?: number): EngineParams.ConditionalTransfer => {
       const hashlockState: Omit<HashlockTransferState, "balance"> = {
         lockHash: getRandomBytes32(),
         expiry: "45000",
@@ -88,7 +86,7 @@ describe("ParamConverter", () => {
         amount: "8",
         assetId: mkAddress("0x0"),
         recipient: bIsRecipient ? signerB.publicIdentifier : getRandomIdentifier(),
-        recipientChainId: 1,
+        recipientChainId: receipientChainId ?? 1,
         recipientAssetId: mkAddress("0x1"),
         type: TransferNames.HashlockTransfer,
         details: hashlockState,
@@ -98,6 +96,23 @@ describe("ParamConverter", () => {
         },
       };
     };
+
+    it("should fail if initiator is receiver for same chain/network", async () => {
+      const params = generateParams(true, chainId);
+      const channelState: FullChannelState = createTestChannelStateWithSigners([signerA, signerB], "setup", {
+        channelAddress: params.channelAddress,
+        networkContext: {
+          ...chainAddresses[chainId],
+          chainId,
+          providerUrl,
+        },
+      });
+
+      const ret = await convertConditionalTransferParams(params, signerB, channelState, chainAddresses, chainReader);
+
+      expect(ret.isError).to.be.true;
+      expect(ret.getError()).to.contain(new InvalidTransferType("An initiator cannot be a receiver on the same chain"));
+    });
 
     it("should work for A", async () => {
       const params = generateParams();


### PR DESCRIPTION
add: todo test in engine

## The Problem
<!--- Why is this change required? What problem does it solve? Bug fix or new feature? -->
<!--- If it fixes an open issue, please link to the issue here. -->
@rhlsthrm: An initiator cannot be a receiver on the same chain
It seemed to work for one transfer leg and fails for another one. It was erroring at the DB level and causing things to be messed up

## The Solution
<!--- Describe the changes you made at a high level -->
<!--- Leave comments on the source diff to draw attention to important low-level specifics -->
throw an error at `convertConditionalTransferParams()`