### PR TITLE
make service optionally started

### DIFF
--- a/ops/start-router.sh
+++ b/ops/start-router.sh
@@ -253,8 +253,12 @@ bash "$root/ops/pull-images.sh" "$prometheus_image" > /dev/null
 cadvisor_image="gcr.io/google-containers/cadvisor:latest"
 bash "$root/ops/pull-images.sh" "$cadvisor_image" > /dev/null
 
-logdna_image="logdna/logspout:v1.2.0"
-bash "$root/ops/pull-images.sh" "$logdna_image" > /dev/null
+# To save time, only pull logdna image if it will be used
+if [[ -z ${logdna_key+x} ]]
+then
+  logdna_image="logdna/logspout:v1.2.0"
+  bash "$root/ops/pull-images.sh" "$logdna_image" > /dev/null
+fi
 
 prometheus_services="prometheus:
     image: $prometheus_image
@@ -298,7 +302,9 @@ logdna_service="logdna:
 
 # TODO we probably want to remove observability from dev env once it's working
 # bc these make indra take a log longer to wake up
-if [[ "$production" == "true" ]]
+
+# Will only use logdna if in prod && API key provided in env
+if [ "$production" == "true" ] && [ -z ${logdna_key+x} ]
 then
   observability_services="$logdna_service
   


### PR DESCRIPTION
## The Problem
<!--- Why is this change required? What problem does it solve? Bug fix or new feature? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Production routers fail when not provided with a logdna key. This should not be a required service.

## The Solution
<!--- Describe the changes you made at a high level -->
<!--- Leave comments on the source diff to draw attention to important low-level specifics -->
Optionally include the logdna image if the key is provided in the env