### PR TITLE
Collateral issues

### DIFF
--- a/modules/documentation/docs/changelog.md
+++ b/modules/documentation/docs/changelog.md
@@ -2,6 +2,9 @@
 
 ## Next Release
 
+- \[router\] Allow payments that exceed `reclaimThreshold` to be collateralized just in time
+- \[router\] Allow `profile.target` to be 0 (always use just in time collateralization)
+
 ## 0.1.0-rc.16
 
 - \[engine\] Retry on deposit race condition

--- a/modules/router/src/services/collateral.ts
+++ b/modules/router/src/services/collateral.ts
@@ -162,15 +162,6 @@ export const requestCollateral = async (
     );
   }
   const profile = profileRes.getValue();
-  if (requestedAmount && BigNumber.from(requestedAmount).gt(profile.reclaimThreshold)) {
-    return Result.fail(
-      new CollateralError(CollateralError.reasons.TargetHigherThanThreshold, {
-        channelAddress: channel.channelAddress,
-        profile,
-        requestedAmount,
-      }),
-    );
-  }
 
   const target = BigNumber.from(requestedAmount ?? profile.target);
 
@@ -178,7 +169,7 @@ export const requestCollateral = async (
 
   const iAmAlice = publicIdentifier === channel.aliceIdentifier;
 
-  const assetIdx = channel.assetIds.findIndex((assetId) => assetId === assetId);
+  const assetIdx = channel.assetIds.findIndex((assetId: string) => assetId === assetId);
   const myBalance = BigNumber.from(getBalanceForAssetId(channel, assetId, iAmAlice ? "alice" : "bob"));
 
   if (myBalance.gte(target)) {

--- a/modules/router/src/test/collateral.spec.ts
+++ b/modules/router/src/test/collateral.spec.ts
@@ -122,6 +122,37 @@ describe(testName, () => {
         amount: transferAmount.add(ethProfile.target).toString(),
       });
     });
+
+    it("should request the amount of the payment if the profile.target is 0", async () => {
+      const { channel } = createTestChannelState(UpdateType.deposit, {
+        alice: mkAddress("0xaaa"),
+        aliceIdentifier: routerPublicIdentifier,
+        assetIds: [AddressZero],
+        balances: [{ to: [mkAddress("0xaaa"), mkAddress("0xbbb")], amount: ["0", "0"] }],
+      });
+      const profile = { ...ethProfile, target: "0" };
+      getRebalanceProfile.returns(Result.ok(profile));
+
+      const res = await justInTimeCollateral(
+        channel,
+        AddressZero,
+        routerPublicIdentifier,
+        node as INodeService,
+        chainReader,
+        log,
+        transferAmount.toString(),
+      );
+      expect(res.getError()).to.be.undefined;
+      expect(res.getValue().channelAddress).to.be.ok;
+      expect(node.sendDepositTx.callCount).to.be.eq(1);
+      expect(node.sendDepositTx.firstCall.args[0]).to.be.deep.eq({
+        channelAddress: channel.channelAddress,
+        publicIdentifier: routerPublicIdentifier,
+        assetId: AddressZero,
+        chainId: channel.networkContext.chainId,
+        amount: transferAmount.toString(),
+      });
+    });
   });
 
   describe("adjustCollateral", () => {
@@ -245,6 +276,68 @@ describe(testName, () => {
       expect(node.sendDepositTx.callCount).to.be.eq(0);
       expect(node.withdraw.callCount).to.be.eq(1);
     });
+
+    it("should reclaim all funds if profile.target is 0 and balance > collateralizeThreshold", async () => {
+      const routerBalance = BigNumber.from(ethProfile.reclaimThreshold).mul(2);
+      const { channel } = createTestChannelState(UpdateType.deposit, {
+        alice: mkAddress("0xaaa"),
+        aliceIdentifier: routerPublicIdentifier,
+        assetIds: [AddressZero],
+        balances: [
+          {
+            to: [mkAddress("0xaaa"), mkAddress("0xbbb")],
+            amount: [routerBalance.toString(), "0"],
+          },
+        ],
+      });
+      const profile = { ...ethProfile, target: "0" };
+      getRebalanceProfile.returns(Result.ok(profile));
+      node.getStateChannel.resolves(Result.ok(channel));
+      node.withdraw.resolves(Result.ok({ channelAddress: channel.channelAddress, transferId: getRandomBytes32() }));
+      const res = await adjustCollateral(
+        channel.channelAddress,
+        AddressZero,
+        routerPublicIdentifier,
+        node as INodeService,
+        chainReader,
+        log,
+      );
+      expect(res.getError()).to.be.undefined;
+      expect(res.getValue().channelAddress).to.be.ok;
+      expect(node.sendDepositTx.callCount).to.be.eq(0);
+      expect(node.withdraw.callCount).to.be.eq(1);
+      expect(node.withdraw.firstCall.args[0]).to.be.deep.eq({
+        channelAddress: channel.channelAddress,
+        publicIdentifier: routerPublicIdentifier,
+        assetId: AddressZero,
+        amount: routerBalance.toString(),
+        recipient: channel.alice,
+      });
+    });
+
+    it("should do nothing if balance < collateralizeThreshold and target = 0", async () => {
+      const { channel } = createTestChannelState(UpdateType.deposit, {
+        alice: mkAddress("0xaaa"),
+        aliceIdentifier: routerPublicIdentifier,
+        assetIds: [AddressZero],
+        balances: [{ to: [mkAddress("0xaaa"), mkAddress("0xbbb")], amount: ["10", "10"] }],
+      });
+      const profile = { ...ethProfile, target: "0" };
+      getRebalanceProfile.returns(Result.ok(profile));
+      node.getStateChannel.resolves(Result.ok(channel));
+      const res = await adjustCollateral(
+        channel.channelAddress,
+        AddressZero,
+        routerPublicIdentifier,
+        node as INodeService,
+        chainReader,
+        log,
+      );
+      expect(res.getError()).to.be.undefined;
+      expect(res.getValue()).to.be.undefined;
+      expect(node.sendDepositTx.callCount).to.be.eq(0);
+      expect(node.withdraw.callCount).to.be.eq(0);
+    });
   });
 
   describe("requestCollateral", () => {
@@ -260,20 +353,6 @@ describe(testName, () => {
         log,
       );
       expect(res.getError().message).to.be.eq(CollateralError.reasons.UnableToGetRebalanceProfile);
-    });
-
-    it("should fail if requestedAmount > reclaimThreshold", async () => {
-      const { channel } = createTestChannelState(UpdateType.deposit);
-      const res = await requestCollateral(
-        channel,
-        AddressZero,
-        routerPublicIdentifier,
-        node as INodeService,
-        chainReader,
-        log,
-        BigNumber.from(ethProfile.reclaimThreshold).add(120).toString(),
-      );
-      expect(res.getError().message).to.be.eq(CollateralError.reasons.TargetHigherThanThreshold);
     });
 
     it("should fail if it cannot get the chainProviders", async () => {
@@ -422,6 +501,32 @@ describe(testName, () => {
         );
         expect(res.isError).to.be.false;
         expect(node.sendDepositTx.callCount).to.be.eq(0);
+        expect(node.reconcileDeposit.callCount).to.be.eq(1);
+      });
+
+      it("if the profile.target is 0 and a requestedAmount is supplied", async () => {
+        const { channel } = createTestChannelState(UpdateType.deposit);
+        const requestedAmount = BigNumber.from(ethProfile.target).add(10000);
+        const profile = { ...ethProfile, target: "0" };
+        getRebalanceProfile.returns(Result.ok(profile));
+        const res = await requestCollateral(
+          channel,
+          AddressZero,
+          routerPublicIdentifier,
+          node as INodeService,
+          chainReader,
+          log,
+          requestedAmount.toString(),
+        );
+        expect(res.isError).to.be.false;
+        expect(node.sendDepositTx.callCount).to.be.eq(1);
+        expect(node.sendDepositTx.firstCall.args[0]).to.be.deep.eq({
+          publicIdentifier: routerPublicIdentifier,
+          channelAddress: channel.channelAddress,
+          chainId: channel.networkContext.chainId,
+          assetId: AddressZero,
+          amount: requestedAmount.sub(channel.balances[0].amount[1]).toString(),
+        });
         expect(node.reconcileDeposit.callCount).to.be.eq(1);
       });
 


### PR DESCRIPTION
## The Problem
<!--- Why is this change required? What problem does it solve? Bug fix or new feature? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x]  Allow for target to be set to 0 - this makes sense because we *always* want to inflight collateralize for now
- [x]  Right now, collateralization logic errors if the `target + transfer amount > reclaim threshold`. This is incorrect. It should only error if `target > reclaim threshold`, because we should always allow a large inflight collateralization of transfer amount

## The Solution
<!--- Describe the changes you made at a high level -->
<!--- Leave comments on the source diff to draw attention to important low-level specifics -->
