### PR TITLE
Check balance before eth fns

### DIFF
--- a/modules/contracts/src.ts/services/ethReader.ts
+++ b/modules/contracts/src.ts/services/ethReader.ts
@@ -243,14 +243,7 @@ export class EthereumChainReader implements IVectorChainReader {
     } catch (e) {
       // Likely means channel contract was not deployed
       // TODO: check for reason?
-      try {
-        onchainBalance =
-          assetId === AddressZero
-            ? await provider!.getBalance(channelAddress)
-            : await new Contract(assetId, ERC20Abi, provider).balanceOf(channelAddress);
-      } catch (e) {
-        return Result.fail(e);
-      }
+      return this.getOnchainBalance(assetId, channelAddress, chainId);
     }
     return Result.ok(onchainBalance);
   }
@@ -498,6 +491,23 @@ export class EthereumChainReader implements IVectorChainReader {
     } catch (e) {
       return Result.fail(e);
     }
+  }
+
+  async getOnchainBalance(assetId: string, balanceOf: string, chainId: number): Promise<Result<BigNumber, ChainError>> {
+    const provider = this.chainProviders[chainId];
+    if (!provider) {
+      return Result.fail(new ChainError(ChainError.reasons.ProviderNotFound));
+    }
+    let onchainBalance: BigNumber;
+    try {
+      onchainBalance =
+        assetId === AddressZero
+          ? await provider!.getBalance(balanceOf)
+          : await new Contract(assetId, ERC20Abi, provider).balanceOf(balanceOf);
+    } catch (e) {
+      return Result.fail(e);
+    }
+    return Result.ok(onchainBalance);
   }
 
   private tryEvm(encodedFunctionData: string, bytecode: string): Result<Uint8Array, Error> {


### PR DESCRIPTION
## The Problem
<!--- Why is this change required? What problem does it solve? Bug fix or new feature? -->
<!--- If it fixes an open issue, please link to the issue here. -->
If signers don't have balance the error does not happen until it tries to send on the provider, throwing an ugly error. We should just check balance before actually making the tx.

## The Solution
<!--- Describe the changes you made at a high level -->
<!--- Leave comments on the source diff to draw attention to important low-level specifics -->
Add balance check to ethService
