### PR TITLE
Fix router ops

### DIFF
--- a/modules/documentation/docs/changelog.md
+++ b/modules/documentation/docs/changelog.md
@@ -2,6 +2,7 @@
 
 ## Next Release
 
+- \[router\] Fix start script to pass mnemonic secret into router.
 ## 0.1.15-beta.0
 
 - \[utils\] Don't use `instanceof` operator

--- a/ops/start-router.sh
+++ b/ops/start-router.sh
@@ -235,11 +235,18 @@ fi
 bash "$root/ops/pull-images.sh" "$router_image_name" > /dev/null
 
 # Add whichever secrets we're using to the router's service config
-if [[ -n "$db_secret" ]]
+if [[ -n "$db_secret" || -n "$mnemonic_secret" ]]
 then
   router_image="$router_image
-    secrets:
+    secrets:"
+  if [[ -n "$db_secret" ]]
+  then router_image="$router_image
       - '$db_secret'"
+  fi
+  if [[ -n "$mnemonic_secret" ]]
+  then router_image="$router_image
+      - '$mnemonic_secret'"
+  fi
 fi
 
 ####################


### PR DESCRIPTION
## The Problem
<!--- Why is this change required? What problem does it solve? Bug fix or new feature? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`make restart-router` failing because mnemonic secret not passed into router.

## The Solution
<!--- Describe the changes you made at a high level -->
<!--- Leave comments on the source diff to draw attention to important low-level specifics -->
Pass mnemonic secret into router.
