### PR TITLE
Allow configuring listen addresses and ports

### DIFF
--- a/modules/auth/src/index.ts
+++ b/modules/auth/src/index.ts
@@ -60,7 +60,9 @@ server.post<{ Body: PostAuthRequestBody }>(
   },
 );
 
-server.listen(config.port, "0.0.0.0", err => {
+const listenPort    = process.env.VECTOR_AUTH_PORT    || config.port;
+const listenAddress = process.env.VECTOR_AUTH_ADDRESS || "0.0.0.0";
+server.listen(listenPort, listenAddress, err => {
   if (err) {
     console.error(err);
     process.exit(1);

--- a/modules/router/src/config.ts
+++ b/modules/router/src/config.ts
@@ -50,8 +50,8 @@ try {
 const mnemonic = mnemonicEnv || vectorConfig.mnemonic;
 
 // Set defaults
-vectorConfig.nodeUrl = vectorConfig.nodeUrl || "http://node:8000";
-vectorConfig.messagingUrl = vectorConfig.messagingUrl || "http://messaging";
+vectorConfig.nodeUrl = process.env.VECTOR_NODE_URL || vectorConfig.nodeUrl || "http://node:8000";
+vectorConfig.messagingUrl = process.env.VECTOR_MESSAGING_URL || vectorConfig.messagingUrl || "http://messaging";
 
 const validate = ajv.compile(VectorRouterConfigSchema);
 const valid = validate(vectorConfig);

--- a/modules/router/src/index.ts
+++ b/modules/router/src/index.ts
@@ -29,8 +29,10 @@ import { IRouter, Router } from "./router";
 import { PrismaStore } from "./services/store";
 import { NatsRouterMessagingService } from "./services/messaging";
 
-const routerPort = 8000;
-const routerBase = `http://router:${routerPort}`;
+const routerListenPort    = process.env.VECTOR_ROUTER_PORT    || 8000;
+const routerListenAddress = process.env.VECTOR_ROUTER_ADDRESS || "router";
+const routerHost          = process.env.VECTOR_ROUTER_HOST    || `${routerListenAddress}:${routerListenPort}`
+const routerBase = `http://${routerHost}`;
 const isAlivePath = "/is-alive";
 const setupPath = "/setup";
 const conditionalTransferCreatedPath = "/conditional-transfer-created";
@@ -225,7 +227,7 @@ server.post(transactionFailedPath, async (request, response) => {
   return response.status(200).send({ message: "success" });
 });
 
-server.listen(routerPort, "0.0.0.0", (err, address) => {
+server.listen(routerListenPort, routerListenAddress, (err, address) => {
   if (err) {
     console.error(err);
     process.exit(1);

--- a/modules/router/src/index.ts
+++ b/modules/router/src/index.ts
@@ -33,6 +33,7 @@ const routerListenPort    = process.env.VECTOR_ROUTER_PORT    || 8000;
 const routerListenAddress = process.env.VECTOR_ROUTER_ADDRESS || "router";
 const routerHost          = process.env.VECTOR_ROUTER_HOST    || `${routerListenAddress}:${routerListenPort}`
 const routerBase = `http://${routerHost}`;
+const nodeUrl = process.env.VECTOR_NODE_URL || config.nodeUrl;
 const isAlivePath = "/is-alive";
 const setupPath = "/setup";
 const conditionalTransferCreatedPath = "/conditional-transfer-created";
@@ -122,7 +123,7 @@ server.addHook("onReady", async () => {
     messagingUrl: config.messagingUrl,
   });
   const nodeService = await RestServerNodeService.connect(
-    config.nodeUrl,
+    nodeUrl,
     logger.child({ module: "RouterNodeService" }),
     evts,
     0,

--- a/modules/server-node/src/index.ts
+++ b/modules/server-node/src/index.ts
@@ -1084,7 +1084,9 @@ server.post<{ Params: { chainId: string }; Body: JsonRpcRequest }>(
   },
 );
 
-server.listen(8000, "0.0.0.0", (err, address) => {
+const listenPort    = process.env.VECTOR_NODE_PORT    || 8000;
+const listenAddress = process.env.VECTOR_NODE_ADDRESS || "0.0.0.0";
+server.listen(listenPort, listenAddress, (err, address) => {
   if (err) {
     logger.error(err);
     process.exit(1);


### PR DESCRIPTION
This should allow configuring these via env vars in the application itself.

* Add env vars:
  * VECTOR_NODE_URL (node url to connect for router)
  * VECTOR_MESSAGING_URL (messaging url to use)
  * VECTOR_NODE_PORT (listen port for node)
  * VECTOR_NODE_ADDRESS (listen address for node)
  * VECTOR_ROUTER_PORT (listen port for router)
  * VECTOR_ROUTER_ADDRESS (listen address for router)
  * VECTOR_ROUTER_HOST (http host for router)
  * VECTOR_AUTH_PORT (listen port for auth)
  * VECTOR_AUTH_ADDRESS (lsten address for auth)

All fall back to their previously hardcoded values of not specified.