### PR TITLE
Don't log secrets to stdout

### DIFF
--- a/modules/router/ops/entry.sh
+++ b/modules/router/ops/entry.sh
@@ -42,7 +42,6 @@ else
   schema="prisma-sqlite/schema.prisma"
   cp prisma-sqlite/schema.prisma dist/schema.prisma
 fi
-echo "VECTOR_DATABASE_URL: $VECTOR_DATABASE_URL"
 
 ########################################
 # Wait for dependencies to wake up

--- a/modules/router/src/index.ts
+++ b/modules/router/src/index.ts
@@ -102,7 +102,7 @@ const evts: EventCallbackConfig = {
 const signer = new ChannelSigner(Wallet.fromMnemonic(config.mnemonic).privateKey);
 
 const logger = pino({ name: signer.publicIdentifier });
-logger.info({ config }, "Loaded config from environment");
+logger.info("Loaded config from environment");
 const server = fastify({ logger, pluginTimeout: 300_000, disableRequestLogging: config.logLevel !== "debug" });
 
 collectDefaultMetrics({ prefix: "router_" });

--- a/modules/server-node/src/index.ts
+++ b/modules/server-node/src/index.ts
@@ -29,7 +29,7 @@ import { ServerNodeError } from "./helpers/errors";
 
 const configuredIdentifier = getPublicIdentifierFromPublicKey(Wallet.fromMnemonic(config.mnemonic).publicKey);
 export const logger = pino({ name: configuredIdentifier, level: config.logLevel ?? "info" });
-logger.info({ config }, "Loaded config from environment");
+logger.info("Loaded config from environment");
 const server = fastify({ logger, pluginTimeout: 300_000, disableRequestLogging: config.logLevel !== "debug" });
 server.register(fastifyCors, {
   origin: "*",


### PR DESCRIPTION
## The Problem
All secrets in config (adminToken, wallet mnemonic in cleartext) as well as database credentials, are logged to stdout as part of normal operations. This makes logs extremely sensitive - just the startup logs would be enough to drain the wallet, even without any internal network access.

## The Solution
Remove the logging for database url and full config.

It can still be desirable to log the rest of the config on startup, which can be done in a future PR by spoecifically redacting the sensitive values.