### PR TITLE
add : retryWrapper for all necessary methods in EthereumChainReader

### DIFF
--- a/modules/contracts/src.ts/services/ethReader.ts
+++ b/modules/contracts/src.ts/services/ethReader.ts
@@ -603,7 +603,6 @@ export class EthereumChainReader implements IVectorChainReader {
     chainId: number,
     targetMethod: (provider: JsonRpcProvider) => Promise<Result<T, ChainError>>
   ): Promise<Result<T, ChainError>> {
-    // TODO : Should we retry this attempt to get provider as well?
     const provider = this.chainProviders[chainId];
     if (!provider) {
       return Result.fail(new ChainError(ChainError.reasons.ProviderNotFound));
@@ -611,11 +610,11 @@ export class EthereumChainReader implements IVectorChainReader {
     let res = await targetMethod(provider);
     let retries;
 
-    // TODO: Would be kinda cool to save all these errors, in case a different error
-    // happens at some point among the retries.
+    // TODO: Save all error history, in case a different error happens
+    // at some point among the retries.
     for (retries = 0; retries < ETH_READER_MAX_RETRIES; retries++) {
       res = await targetMethod(provider);
-      if (!res.getError()) {
+      if (!res.isError) {
         break;
       }
     }

--- a/modules/contracts/src.ts/services/ethReader.ts
+++ b/modules/contracts/src.ts/services/ethReader.ts
@@ -610,12 +610,14 @@ export class EthereumChainReader implements IVectorChainReader {
     let res = await targetMethod(provider);
     let retries;
 
-    // TODO: Save all error history, in case a different error happens
-    // at some point among the retries.
-    for (retries = 0; retries < ETH_READER_MAX_RETRIES; retries++) {
-      res = await targetMethod(provider);
-      if (!res.isError) {
-        break;
+    if (res.isError) {
+      // TODO: Save all error history, in case a different error
+      // happens at some point among the retries.
+      for (retries = 1; retries < ETH_READER_MAX_RETRIES; retries++) {
+        res = await targetMethod(provider);
+        if (!res.isError) {
+          break;
+        }
       }
     }
     return res;

--- a/modules/types/src/constants.ts
+++ b/modules/types/src/constants.ts
@@ -36,4 +36,4 @@ export const getConfirmationsForChain = (chainId: number): number => {
 };
 
 // ETH Reader - how many attempts / retries will we do upon failure?
-const ETH_READER_MAX_RETRIES = 5;
+export const ETH_READER_MAX_RETRIES = 5;

--- a/modules/types/src/constants.ts
+++ b/modules/types/src/constants.ts
@@ -34,3 +34,6 @@ export const CHAINS_WITH_NO_CONFIRMATIONS = [1, 1337, 1338, 1340, 1341, 1342];
 export const getConfirmationsForChain = (chainId: number): number => {
   return CHAINS_WITH_NO_CONFIRMATIONS.includes(chainId) ? 0 : NUM_CONFIRMATIONS;
 };
+
+// ETH Reader - how many attempts / retries will we do upon failure?
+const ETH_READER_MAX_RETRIES = 5;


### PR DESCRIPTION
## The Problem
Fixes #465 
>Dealing with eth nodes is often unreliable. The chainReader should retry these calls, especially since no gas is wasted. Ideally we'd sort by error messages, but we don't even need the implementation to be that complex.
<!--- Why is this change required? What problem does it solve? Bug fix or new feature? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## The Solution
Add `retryWrapper` method and implement across the board. Have a constant defined amount # of retries.
<!--- Describe the changes you made at a high level -->
<!--- Leave comments on the source diff to draw attention to important low-level specifics -->
