### PR TITLE
Simplify gas fee calculation

### DIFF
--- a/modules/contracts/src.ts/services/index.ts
+++ b/modules/contracts/src.ts/services/index.ts
@@ -1,5 +1,5 @@
 export { EthereumChainReader as VectorChainReader } from "./ethReader";
-export { EthereumChainService as VectorChainService, EXTRA_GAS_PRICE, waitForTransaction } from "./ethService";
+export { EthereumChainService as VectorChainService, waitForTransaction } from "./ethService";
 
 /*
 const harmonyChainIds = [];

--- a/modules/engine/src/index.ts
+++ b/modules/engine/src/index.ts
@@ -1,5 +1,4 @@
 import { Vector } from "@connext/vector-protocol";
-import { EXTRA_GAS_PRICE } from "@connext/vector-contracts";
 import {
   ChainAddresses,
   IChannelSigner,
@@ -658,8 +657,7 @@ export class VectorEngine implements IVectorEngine {
     if (gasPriceRes.isError) {
       Result.fail(gasPriceRes.getError()!);
     }
-    const _gasPrice = gasPriceRes.getValue();
-    const gasPrice = _gasPrice.add(EXTRA_GAS_PRICE);
+    const gasPrice = gasPriceRes.getValue();
     this.logger.info(
       { method, chainId: channel.networkContext.chainId, channel: channel.channelAddress },
       "Got gas price",

--- a/modules/router/src/services/fees.ts
+++ b/modules/router/src/services/fees.ts
@@ -371,7 +371,9 @@ export const calculateEstimatedGasFee = async (
     fromChannelFee =
       participantFromChannel === "alice" && fromChannelCode.getValue() === "0x"
         ? GAS_ESTIMATES.createChannelAndDepositAlice
-        : GAS_ESTIMATES.depositAlice;
+        : participantFromChannel === "alice"
+        ? GAS_ESTIMATES.depositAlice
+        : GAS_ESTIMATES.depositBob;
   }
 
   // when forwarding a transfer, the only immediate costs on the receiver-side
@@ -483,8 +485,6 @@ export const calculateEstimatedGasFee = async (
   return Result.ok({
     [fromChannel.channelAddress]: fromChannelFee,
     [toChannel.channelAddress]:
-      toChannelCode.getValue() === "0x"
-        ? GAS_ESTIMATES.createChannelAndDepositAlice
-        : GAS_ESTIMATES.depositAlice,
+      toChannelCode.getValue() === "0x" ? GAS_ESTIMATES.createChannelAndDepositAlice : GAS_ESTIMATES.depositAlice,
   });
 };

--- a/modules/router/src/services/fees.ts
+++ b/modules/router/src/services/fees.ts
@@ -5,10 +5,9 @@ import {
   Result,
   REDUCED_GAS_PRICE,
   SIMPLE_WITHDRAWAL_GAS_ESTIMATE,
+  GAS_ESTIMATES,
 } from "@connext/vector-types";
 import { getBalanceForAssetId, getParticipant, getRandomBytes32, TESTNETS_WITH_FEES } from "@connext/vector-utils";
-import { ChannelFactory, ChannelMastercopy, TestToken } from "@connext/vector-contracts";
-import { Interface } from "@ethersproject/abi";
 import { BigNumber } from "@ethersproject/bignumber";
 import { AddressZero, Zero } from "@ethersproject/constants";
 import { BaseLogger } from "pino";
@@ -358,40 +357,21 @@ export const calculateEstimatedGasFee = async (
     );
   }
 
-  // Get the gas estimates
-  const fromGasEstimates = await getGasEstimates(
-    fromChannel,
-    fromAssetId,
-    amountToSend,
-    routerPublicIdentifier,
-    ethReader,
-  );
-  const toGasEstimates = await getGasEstimates(
-    toChannel,
-    toAssetId,
-    amountToSend, // safe to not convert, amounts dont impact gas
-    routerPublicIdentifier,
-    ethReader,
-  );
-  if (fromGasEstimates.isError || toGasEstimates.isError) {
-    return Result.fail(fromGasEstimates.getError() ?? toGasEstimates.getError()!);
-  }
-
   const fromProfile = rebalanceFromProfile.getValue();
   let fromChannelFee = Zero; // start with no actions
   if (finalFromBalance.gt(fromProfile.reclaimThreshold)) {
     // There will be a post-resolution reclaim of funds
     fromChannelFee =
       fromChannelCode.getValue() === "0x"
-        ? fromGasEstimates.getValue().createChannel.add(SIMPLE_WITHDRAWAL_GAS_ESTIMATE)
+        ? GAS_ESTIMATES.createChannel.add(SIMPLE_WITHDRAWAL_GAS_ESTIMATE)
         : SIMPLE_WITHDRAWAL_GAS_ESTIMATE;
   } else if (finalFromBalance.lt(fromProfile.collateralizeThreshold)) {
     // There will be a post-resolution sender collateralization
     // gas estimates are participant sensitive, so this is safe to do
     fromChannelFee =
       participantFromChannel === "alice" && fromChannelCode.getValue() === "0x"
-        ? fromGasEstimates.getValue().createChannelAndDepositAlice
-        : fromGasEstimates.getValue().deposit;
+        ? GAS_ESTIMATES.createChannelAndDepositAlice
+        : GAS_ESTIMATES.depositAlice;
   }
 
   // when forwarding a transfer, the only immediate costs on the receiver-side
@@ -477,7 +457,7 @@ export const calculateEstimatedGasFee = async (
     );
     return Result.ok({
       [fromChannel.channelAddress]: fromChannelFee,
-      [toChannel.channelAddress]: toGasEstimates.getValue().deposit,
+      [toChannel.channelAddress]: GAS_ESTIMATES.depositBob,
     });
   }
 
@@ -504,88 +484,7 @@ export const calculateEstimatedGasFee = async (
     [fromChannel.channelAddress]: fromChannelFee,
     [toChannel.channelAddress]:
       toChannelCode.getValue() === "0x"
-        ? toGasEstimates.getValue().createChannelAndDepositAlice
-        : toGasEstimates.getValue().deposit,
-  });
-};
-
-const getGasEstimates = async (
-  channel: FullChannelState,
-  assetId: string,
-  amount: BigNumber, // use fee amount
-  routerPublicIdentifier: string,
-  chainService: IVectorChainReader,
-): Promise<
-  Result<{ deposit: BigNumber; createChannel: BigNumber; createChannelAndDepositAlice: BigNumber }, FeeError>
-> => {
-  const iFactory = new Interface(ChannelFactory.abi);
-  const iMastercopy = new Interface(ChannelMastercopy.abi);
-  const iToken = new Interface(TestToken.abi);
-  const sender = routerPublicIdentifier === channel.aliceIdentifier ? channel.alice : channel.bob;
-  const createAndDepositGas =
-    sender === channel.alice
-      ? await chainService.estimateGas(channel.networkContext.chainId, {
-          to: channel.networkContext.channelFactoryAddress,
-          data: iFactory.encodeFunctionData("createChannelAndDepositAlice", [
-            channel.alice,
-            channel.bob,
-            assetId,
-            amount,
-          ]),
-          from: sender,
-          value: assetId === AddressZero ? amount : Zero,
-        })
-      : Result.ok(BigNumber.from(0));
-  if (createAndDepositGas.isError) {
-    return Result.fail(
-      new FeeError(FeeError.reasons.ChainError, {
-        chainServiceMethod: "estimateGas:createChannelAndDepositAlice",
-        error: jsonifyError(createAndDepositGas.getError()!),
-      }),
-    );
-  }
-
-  const createGas = await chainService.estimateGas(channel.networkContext.chainId, {
-    to: channel.networkContext.channelFactoryAddress,
-    data: iFactory.encodeFunctionData("createChannel", [channel.alice, channel.bob]),
-    from: sender,
-  });
-  if (createGas.isError) {
-    return Result.fail(
-      new FeeError(FeeError.reasons.ChainError, {
-        chainServiceMethod: "estimateGas:createChannel",
-        error: jsonifyError(createGas.getError()!),
-      }),
-    );
-  }
-
-  const deposit =
-    sender === channel.alice
-      ? await chainService.estimateGas(channel.networkContext.chainId, {
-          to: channel.channelAddress,
-          from: sender,
-          data: iMastercopy.encodeFunctionData("depositAlice", [assetId, amount]),
-          value: assetId === AddressZero ? amount : Zero,
-        })
-      : await chainService.estimateGas(channel.networkContext.chainId, {
-          to: channel.channelAddress,
-          from: sender,
-          data:
-            assetId === AddressZero ? "0x" : iToken.encodeFunctionData("transfer", [channel.channelAddress, amount]),
-        });
-
-  if (deposit.isError) {
-    return Result.fail(
-      new FeeError(FeeError.reasons.ChainError, {
-        chainServiceMethod: "estimateGas:deposit",
-        error: jsonifyError(deposit.getError()!),
-      }),
-    );
-  }
-
-  return Result.ok({
-    createChannelAndDepositAlice: createAndDepositGas.getValue(),
-    createChannel: createGas.getValue(),
-    deposit: deposit.getValue(),
+        ? GAS_ESTIMATES.createChannelAndDepositAlice
+        : GAS_ESTIMATES.depositAlice,
   });
 };

--- a/modules/router/src/test/services/fees.spec.ts
+++ b/modules/router/src/test/services/fees.spec.ts
@@ -42,13 +42,7 @@ describe(testName, () => {
 
     // setup gas fees stubs
     // from channel calls
-    ethReader.estimateGas.onCall(0).resolves(Result.ok(GAS_ESTIMATES.createChannelAndDepositAlice));
-    ethReader.estimateGas.onCall(1).resolves(Result.ok(GAS_ESTIMATES.createChannel));
-    ethReader.estimateGas.onCall(2).resolves(Result.ok(GAS_ESTIMATES.depositAlice));
     // to channel calls
-    ethReader.estimateGas.onCall(3).resolves(Result.ok(GAS_ESTIMATES.createChannelAndDepositAlice));
-    ethReader.estimateGas.onCall(4).resolves(Result.ok(GAS_ESTIMATES.createChannel));
-    ethReader.estimateGas.onCall(5).resolves(Result.ok(GAS_ESTIMATES.depositAlice));
   });
 
   afterEach(() => {
@@ -573,10 +567,9 @@ describe(testName, () => {
         };
         fromChannel.aliceIdentifier = fromChannel.bobIdentifier;
         fromChannel.bobIdentifier = routerIdentifier;
+
         // setup gas fees stubs
         // from channel calls
-        ethReader.estimateGas.onCall(0).resolves(Result.ok(GAS_ESTIMATES.createChannel));
-        ethReader.estimateGas.onCall(1).resolves(Result.ok(GAS_ESTIMATES.depositBob));
         const result = await feesService.calculateEstimatedGasFee(
           BigNumber.from(3),
           toAssetId,
@@ -654,8 +647,6 @@ describe(testName, () => {
         toChannel.bobIdentifier = routerIdentifier;
 
         // setup gas for to channel calls
-        ethReader.estimateGas.onCall(3).resolves(Result.ok(GAS_ESTIMATES.createChannel));
-        ethReader.estimateGas.onCall(4).resolves(Result.ok(GAS_ESTIMATES.depositBob));
 
         const result = await feesService.calculateEstimatedGasFee(
           toSend,

--- a/modules/types/src/chain.ts
+++ b/modules/types/src/chain.ts
@@ -10,8 +10,8 @@ import { ChainProviders, HydratedProviders } from "./network";
 import { RegisteredTransfer, TransferName, TransferState, WithdrawCommitmentJson } from "./transferDefinitions";
 
 export const GAS_ESTIMATES = {
-  createChannelAndDepositAlice: BigNumber.from(205_000), // 0x5a78baf521e5739b2b63626566f6b360a242b52734662db439a2c3256d3e1f97
-  createChannel: BigNumber.from(130_000), // 0x45690e81cfc5576d11ecda7938ce91af513a873f8c7e4f26bf2a898ee45ae8ab
+  createChannelAndDepositAlice: BigNumber.from(200_000), // 0x5a78baf521e5739b2b63626566f6b360a242b52734662db439a2c3256d3e1f97
+  createChannel: BigNumber.from(150_000), // 0x45690e81cfc5576d11ecda7938ce91af513a873f8c7e4f26bf2a898ee45ae8ab
   depositAlice: BigNumber.from(85_000), // 0x0ed5459c7366d862177408328591c6df5c534fe4e1fbf4a5dd0abbe3d9c761b3
   depositBob: BigNumber.from(50_000),
   withdraw: BigNumber.from(95_000), // 0x4d4466ed10b5d39c0a80be859dc30bca0120b5e8de10ed7155cc0b26da574439

--- a/modules/types/src/chain.ts
+++ b/modules/types/src/chain.ts
@@ -10,8 +10,8 @@ import { ChainProviders, HydratedProviders } from "./network";
 import { RegisteredTransfer, TransferName, TransferState, WithdrawCommitmentJson } from "./transferDefinitions";
 
 export const GAS_ESTIMATES = {
-  createChannelAndDepositAlice: BigNumber.from(200_000), // 0x5a78baf521e5739b2b63626566f6b360a242b52734662db439a2c3256d3e1f97
-  createChannel: BigNumber.from(150_000), // 0x45690e81cfc5576d11ecda7938ce91af513a873f8c7e4f26bf2a898ee45ae8ab
+  createChannelAndDepositAlice: BigNumber.from(205_000), // 0x5a78baf521e5739b2b63626566f6b360a242b52734662db439a2c3256d3e1f97
+  createChannel: BigNumber.from(130_000), // 0x45690e81cfc5576d11ecda7938ce91af513a873f8c7e4f26bf2a898ee45ae8ab
   depositAlice: BigNumber.from(85_000), // 0x0ed5459c7366d862177408328591c6df5c534fe4e1fbf4a5dd0abbe3d9c761b3
   depositBob: BigNumber.from(50_000),
   withdraw: BigNumber.from(95_000), // 0x4d4466ed10b5d39c0a80be859dc30bca0120b5e8de10ed7155cc0b26da574439

--- a/modules/types/src/chain.ts
+++ b/modules/types/src/chain.ts
@@ -9,13 +9,13 @@ import { TransactionEvent, TransactionEventMap } from "./event";
 import { ChainProviders, HydratedProviders } from "./network";
 import { RegisteredTransfer, TransferName, TransferState, WithdrawCommitmentJson } from "./transferDefinitions";
 
-// export const GAS_ESTIMATES = {
-//   createChannelAndDepositAlice: BigNumber.from(200_000), // 0x5a78baf521e5739b2b63626566f6b360a242b52734662db439a2c3256d3e1f97
-//   createChannel: BigNumber.from(150_000), // 0x45690e81cfc5576d11ecda7938ce91af513a873f8c7e4f26bf2a898ee45ae8ab
-//   depositAlice: BigNumber.from(85_000), // 0x0ed5459c7366d862177408328591c6df5c534fe4e1fbf4a5dd0abbe3d9c761b3
-//   depositBob: BigNumber.from(50_000),
-//   withdraw: BigNumber.from(95_000), // 0x4d4466ed10b5d39c0a80be859dc30bca0120b5e8de10ed7155cc0b26da574439
-// };
+export const GAS_ESTIMATES = {
+  createChannelAndDepositAlice: BigNumber.from(200_000), // 0x5a78baf521e5739b2b63626566f6b360a242b52734662db439a2c3256d3e1f97
+  createChannel: BigNumber.from(150_000), // 0x45690e81cfc5576d11ecda7938ce91af513a873f8c7e4f26bf2a898ee45ae8ab
+  depositAlice: BigNumber.from(85_000), // 0x0ed5459c7366d862177408328591c6df5c534fe4e1fbf4a5dd0abbe3d9c761b3
+  depositBob: BigNumber.from(50_000),
+  withdraw: BigNumber.from(95_000), // 0x4d4466ed10b5d39c0a80be859dc30bca0120b5e8de10ed7155cc0b26da574439
+};
 
 // NOTE: you cannot easily use `estimateGas` to calculate the costs
 // of a withdrawal onchain. This is because to make sure that the


### PR DESCRIPTION
## The Problem
<!--- Why is this change required? What problem does it solve? Bug fix or new feature? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Gas fees calculations were breaking when using estimate gas.

## The Solution
<!--- Describe the changes you made at a high level -->
<!--- Leave comments on the source diff to draw attention to important low-level specifics -->
- Use hardcoded gas amount for fee quotes.
- Use 1M gas limit for all tx sends.
