### PR TITLE
Serialize provider calls in metrics

### DIFF
--- a/modules/router/src/metrics.ts
+++ b/modules/router/src/metrics.ts
@@ -217,14 +217,12 @@ export const onchainLiquidity = new Gauge({
         );
 
         // tokens
-        await Promise.all(
-          Object.entries(rebalancedTokens[chainId] ?? {}).map(async ([assetId, config]) => {
-            const balance = await config.contract.balanceOf(signerAddress);
-            const assetName: string = getAssetName(Number(chainId), assetId);
-            const toSet = await parseBalanceToNumber(balance, chainId, assetId);
-            this.set({ chainName: chainInfo?.name ?? chainId, chainId, assetName, assetId }, toSet);
-          }),
-        );
+        for (const [assetId, config] of Object.entries(rebalancedTokens[chainId] ?? {})) {
+          const balance = await config.contract.balanceOf(signerAddress);
+          const assetName: string = getAssetName(Number(chainId), assetId);
+          const toSet = await parseBalanceToNumber(balance, chainId, assetId);
+          this.set({ chainName: chainInfo?.name ?? chainId, chainId, assetName, assetId }, toSet);
+        }
       }),
     );
   },


### PR DESCRIPTION
## The Problem
<!--- Why is this change required? What problem does it solve? Bug fix or new feature? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Our router is barfing ethers provider errors constantly.

## The Solution
<!--- Describe the changes you made at a high level -->
<!--- Leave comments on the source diff to draw attention to important low-level specifics -->
Based on suggestion here: https://github.com/ethers-io/ethers.js/issues/1390#issuecomment-804918969, try and serialize some calls.
