### PR TITLE
Implement chain provider class with fallback capabilities

### DIFF
--- a/modules/contracts/src.ts/constants.ts
+++ b/modules/contracts/src.ts/constants.ts
@@ -1,13 +1,15 @@
 import { HDNode } from "@ethersproject/hdnode";
 import { Wallet } from "@ethersproject/wallet";
 import { JsonRpcProvider } from "@ethersproject/providers";
-import { network, ethers }from "hardhat";
+import { ChainProvider } from "@connext/vector-types";
+import { network, ethers } from "hardhat";
 import pino from "pino";
 
 // Get defaults from env
 const chainProviders = JSON.parse(process.env.CHAIN_PROVIDERS ?? "{}");
+
 const chainId = Object.keys(chainProviders)[0];
-const url = Object.values(chainProviders)[0];
+const urls = Object.values(chainProviders)[0];
 const mnemonic = process.env.SUGAR_DADDY ?? "candy maple cake sugar pudding cream honey rich smooth crumble sweet treat";
 
 export const defaultLogLevel = process.env.LOG_LEVEL || "info";
@@ -15,9 +17,9 @@ export const logger = pino({ level: defaultLogLevel });
 
 export const networkName = network.name;
 
-export const provider = url
-  ? new JsonRpcProvider(url as string, parseInt(chainId))
-  : ethers.provider as JsonRpcProvider;
+export const provider = urls
+  ? new ChainProvider(parseInt(chainId), (urls as string).split(","))
+  : new ChainProvider(parseInt(chainId), [ethers.provider as JsonRpcProvider]);
 
 const hdNode = HDNode.fromMnemonic(mnemonic).derivePath("m/44'/60'/0'/0");
 

--- a/modules/contracts/src.ts/services/ethService.ts
+++ b/modules/contracts/src.ts/services/ethService.ts
@@ -17,6 +17,7 @@ import {
   StringifiedTransactionResponse,
   TransactionResponseWithResult,
   getConfirmationsForChain,
+  ChainProvider,
 } from "@connext/vector-types";
 import {
   bufferify,
@@ -30,7 +31,7 @@ import { Interface } from "@ethersproject/abi";
 import { Signer } from "@ethersproject/abstract-signer";
 import { BigNumber } from "@ethersproject/bignumber";
 import { Contract } from "@ethersproject/contracts";
-import { JsonRpcProvider, TransactionReceipt, TransactionResponse } from "@ethersproject/providers";
+import { TransactionReceipt, TransactionResponse } from "@ethersproject/providers";
 import { keccak256 } from "@ethersproject/keccak256";
 import { Wallet } from "@ethersproject/wallet";
 import { BaseLogger } from "pino";
@@ -47,7 +48,7 @@ export const EXTRA_GAS = 50_000;
 export const BIG_GAS_LIMIT = BigNumber.from(1_000_000); // 1M gas should cover all Connext txs
 
 export const waitForTransaction = async (
-  provider: JsonRpcProvider,
+  provider: ChainProvider,
   transactionHash: string,
   confirmations?: number,
   timeout?: number,
@@ -72,7 +73,7 @@ export class EthereumChainService extends EthereumChainReader implements IVector
   };
   constructor(
     private readonly store: IChainServiceStore,
-    chainProviders: { [chainId: string]: JsonRpcProvider },
+    chainProviders: { [chainId: string]: ChainProvider },
     signer: string | Signer,
     log: BaseLogger,
     private readonly defaultRetries = 1,

--- a/modules/iframe-app/src/ConnextManager.tsx
+++ b/modules/iframe-app/src/ConnextManager.tsx
@@ -7,7 +7,7 @@ import {
   EngineParams,
   jsonifyError,
 } from "@connext/vector-types";
-import { ChannelSigner, constructRpcRequest, safeJsonParse } from "@connext/vector-utils";
+import { ChannelSigner, constructRpcRequest, parseProviders, safeJsonParse } from "@connext/vector-utils";
 import { hexlify } from "@ethersproject/bytes";
 import { entropyToMnemonic } from "@ethersproject/hdnode";
 import { keccak256 } from "@ethersproject/keccak256";
@@ -64,7 +64,7 @@ export default class ConnextManager {
         const ableToMigrate = await this.ableToMigrate(
           storedEntropy,
           chainAddresses ?? config.chainAddresses,
-          chainProviders,
+          parseProviders(chainProviders),
           messagingUrl ?? config.messagingUrl,
         );
         if (ableToMigrate) {
@@ -91,7 +91,7 @@ export default class ConnextManager {
     this.browserNode = await BrowserNode.connect({
       signer,
       chainAddresses: chainAddresses ?? config.chainAddresses,
-      chainProviders,
+      chainProviders: parseProviders(chainProviders),
       logger: pino(),
       messagingUrl: messagingUrl ?? config.messagingUrl,
       authUrl: config.authUrl,

--- a/modules/protocol/src/testing/constants.ts
+++ b/modules/protocol/src/testing/constants.ts
@@ -1,11 +1,11 @@
-import { JsonRpcProvider } from "@ethersproject/providers";
+import { ChainProvider } from "@connext/vector-types";
 import { Wallet } from "@ethersproject/wallet";
 
 import { env } from "./env";
 
 export const chainId = parseInt(Object.keys(env.chainProviders)[0]);
 export const tokenAddress = env.chainAddresses[chainId]?.testTokenAddress ?? "";
-export const provider = new JsonRpcProvider(env.chainProviders[chainId], chainId);
+export const provider = new ChainProvider(chainId, env.chainProviders[chainId]);
 
 export const sugarDaddy = Wallet.fromMnemonic(env.sugarDaddyMnemonic).connect(provider);
 export const rando = Wallet.createRandom().connect(provider);

--- a/modules/router/src/config.ts
+++ b/modules/router/src/config.ts
@@ -18,7 +18,7 @@ export type RebalanceProfile = Static<typeof RebalanceProfileSchema>;
 const VectorRouterConfigSchema = Type.Object({
   adminToken: Type.String(),
   allowedSwaps: Type.Array(AllowedSwapSchema),
-  chainProviders: Type.Dict(TUrl),
+  chainProviders: Type.Dict(Type.String()),
   dbUrl: Type.Optional(TUrl),
   nodeUrl: TUrl,
   logLevel: Type.Optional(

--- a/modules/router/src/index.ts
+++ b/modules/router/src/index.ts
@@ -4,7 +4,7 @@ import fastify from "fastify";
 import pino from "pino";
 import { Evt } from "evt";
 import { VectorChainReader } from "@connext/vector-contracts";
-import { EventCallbackConfig, hydrateProviders, RestServerNodeService, ChannelSigner } from "@connext/vector-utils";
+import { EventCallbackConfig, hydrateProviders, parseProviders, RestServerNodeService, ChannelSigner } from "@connext/vector-utils";
 import {
   IsAlivePayload,
   ConditionalTransferCreatedPayload,
@@ -119,8 +119,8 @@ const server = fastify({
 collectDefaultMetrics({ prefix: "router_" });
 
 let router: IRouter;
-const store = new PrismaStore();
-const hydratedProviders = hydrateProviders(config.chainProviders);
+const store = new PrismaStore()
+const hydratedProviders = hydrateProviders(parseProviders(config.chainProviders));
 const chainService = new VectorChainReader(hydratedProviders, logger.child({ module: "RouterChainReader" }));
 const messagingService = new NatsRouterMessagingService({
   signer,

--- a/modules/router/src/metrics.ts
+++ b/modules/router/src/metrics.ts
@@ -13,6 +13,7 @@ import {
   getMainnetEquivalent,
   getExchangeRateInEth,
   calculateExchangeWad,
+  parseProviders,
 } from "@connext/vector-utils";
 import { BigNumber, BigNumberish } from "@ethersproject/bignumber";
 import { AddressZero } from "@ethersproject/constants";
@@ -35,7 +36,7 @@ const config = getConfig();
 ///// Helpers/Utils
 export const wallet = Wallet.fromMnemonic(config.mnemonic);
 export const signerAddress = wallet.address;
-export const hydrated: HydratedProviders = hydrateProviders(config.chainProviders);
+export const hydrated: HydratedProviders = hydrateProviders(parseProviders(config.chainProviders));
 export const rebalancedTokens: {
   [chainId: string]: {
     [assetId: string]: {

--- a/modules/router/src/test/autoRebalance.spec.ts
+++ b/modules/router/src/test/autoRebalance.spec.ts
@@ -1,9 +1,8 @@
 import { VectorChainReader } from "@connext/vector-contracts";
 import { expect, getRandomBytes32, getTestLoggers, mkAddress, mkBytes32 } from "@connext/vector-utils";
 import Sinon from "sinon";
-import { AllowedSwap, Result } from "@connext/vector-types";
+import { AllowedSwap, ChainProvider, Result } from "@connext/vector-types";
 import { Wallet } from "@ethersproject/wallet";
-import { JsonRpcProvider } from "@ethersproject/providers";
 import { BigNumber } from "@ethersproject/bignumber";
 import { parseEther } from "@ethersproject/units";
 import axios from "axios";
@@ -22,7 +21,7 @@ describe(testName, () => {
   describe("rebalanceIfNeeded", () => {
     let wallet: Sinon.SinonStubbedInstance<Wallet>;
     let chainService: Sinon.SinonStubbedInstance<VectorChainReader>;
-    let hydratedProviders: { [chainId: number]: Sinon.SinonStubbedInstance<JsonRpcProvider> };
+    let hydratedProviders: { [chainId: number]: Sinon.SinonStubbedInstance<ChainProvider> };
     let mockAxios: Sinon.SinonStubbedInstance<any>;
     let store: Sinon.SinonStubbedInstance<PrismaStore>;
 
@@ -31,8 +30,8 @@ describe(testName, () => {
 
       chainService = Sinon.createStubInstance(VectorChainReader);
       hydratedProviders = {
-        1337: Sinon.createStubInstance(JsonRpcProvider),
-        1338: Sinon.createStubInstance(JsonRpcProvider),
+        1337: Sinon.createStubInstance(ChainProvider),
+        1338: Sinon.createStubInstance(ChainProvider),
       };
       const parseBalanceStub = Sinon.stub(metrics, "getDecimals").resolves(18);
 

--- a/modules/router/src/test/utils/mocks.ts
+++ b/modules/router/src/test/utils/mocks.ts
@@ -1,7 +1,7 @@
-import { JsonRpcProvider } from "@ethersproject/providers";
+import { ChainProvider } from "@connext/vector-types";
 import { createStubInstance } from "sinon";
 
-export const mockProvider = createStubInstance(JsonRpcProvider, {
+export const mockProvider = createStubInstance(ChainProvider, {
   waitForTransaction: Promise.resolve({ logs: [] } as any),
   getNetwork: Promise.resolve({ chainId: 1337, name: "" }),
 });

--- a/modules/server-node/src/index.ts
+++ b/modules/server-node/src/index.ts
@@ -18,7 +18,7 @@ import {
   GetTransfersFilterOptsSchema,
   VectorErrorJson,
 } from "@connext/vector-types";
-import { constructRpcRequest, getPublicIdentifierFromPublicKey, hydrateProviders } from "@connext/vector-utils";
+import { constructRpcRequest, getPublicIdentifierFromPublicKey, hydrateProviders, parseProviders } from "@connext/vector-utils";
 import { WithdrawCommitment } from "@connext/vector-contracts";
 import { Static, Type } from "@sinclair/typebox";
 import { Wallet } from "@ethersproject/wallet";
@@ -45,7 +45,7 @@ server.register(fastifyCors, {
 
 export const store = new PrismaStore();
 
-export const _providers = hydrateProviders(config.chainProviders);
+export const _providers = hydrateProviders(parseProviders(config.chainProviders));
 
 server.addHook("onReady", async () => {
   const persistedNodes = await store.getNodeIndexes();

--- a/modules/types/src/network.ts
+++ b/modules/types/src/network.ts
@@ -1,9 +1,53 @@
-import { JsonRpcProvider } from "@ethersproject/providers";
+import { JsonRpcProvider, FallbackProvider } from "@ethersproject/providers";
 
 export type ChainProviders = {
-  [chainId: number]: string;
+  [chainId: number]: string[]
 };
 
 export type HydratedProviders = {
-  [chainId: number]: JsonRpcProvider;
+  [chainId: number]: ChainProvider;
 };
+
+/* Represents an aggregate of providers for a particular chain. Leverages functionality from
+*  @ethersproject/providers/FallbackProvider in order to fallback to other providers in the
+*  event of failed requests.
+*/
+export class ChainProvider extends FallbackProvider {
+    readonly chainId: number;
+    readonly providerUrls: string[];
+
+    constructor(chainId: number, providers: string[] | JsonRpcProvider[], stallTimeout?: number) {
+      // We'll collect all the provider URLs as we hydrate each provider.
+      var providerUrls: string[] = [];
+      super(
+        // Map the provider URLs into JsonRpcProviders 
+        providers.map((provider: string | JsonRpcProvider, priority: number) => {
+          const hydratedProvider = (typeof(provider) === "string") ? new JsonRpcProvider(provider, chainId) : provider;
+          providerUrls.push(hydratedProvider.connection.url);
+          return {
+            provider: hydratedProvider,
+            // Invert priority as higher values are used first.
+            priority: -priority,
+            // Timeout before also triggering the next provider; this does not stop
+            // this provider and if its result comes back before a quorum is reached
+            // it will be incorporated into the vote
+            // - lower values will cause more network traffic but may result in a
+            //   faster retult.
+            // TODO: Should we have our own default timeout defined, as well as a config option for this?
+            // Default timeout is written as either 2sec or .75sec (in @ethers-project/fallback-provider.ts):
+            // config.stallTimeout = isCommunityResource(configOrProvider) ? 2000: 750;
+            stallTimeout: stallTimeout
+          }
+        }),
+        // Quorum stays at 1, since we only ever want to send reqs to 1 node at a time.
+        1
+      );
+      this.chainId = chainId;
+      this.providerUrls = providerUrls;
+    }
+
+    send(method: string, params: { [name: string]: any }): Promise<any> {
+        return this.perform(method, params);
+    }
+
+}

--- a/modules/utils/src/eth.ts
+++ b/modules/utils/src/eth.ts
@@ -2,6 +2,7 @@ import { ChainProviders, HydratedProviders } from "@connext/vector-types";
 import { Provider } from "@ethersproject/abstract-provider";
 import { BigNumber } from "@ethersproject/bignumber";
 import { JsonRpcProvider } from "@ethersproject/providers";
+import { ChainProvider } from "@connext/vector-types";
 
 const classicProviders = ["https://www.ethercluster.com/etc"];
 const classicChainIds = [61];
@@ -20,10 +21,21 @@ export const getGasPrice = async (provider: Provider, providedChainId?: number):
   return chainId === 100 && price.lt(minGasPrice) ? minGasPrice : price;
 };
 
+/// Parse CSV formatted provider dict into ChainProviders, which uses a list of Urls per chainId.
+export const parseProviders = (prevChainProviders: { [chainId: string]: string }): ChainProviders => {
+  var chainProviders: ChainProviders = {}
+  Object.entries(prevChainProviders).forEach(
+    ([chainId, urlString]) => {
+      chainProviders[chainId] = urlString.split(",");
+    }
+  );
+  return chainProviders
+}
+
 export const hydrateProviders = (chainProviders: ChainProviders): HydratedProviders => {
-  const hydratedProviders: { [url: string]: JsonRpcProvider } = {};
+  const hydratedProviders: { [url: string]: ChainProvider } = {};
   Object.entries(chainProviders).map(([chainId, url]) => {
-    hydratedProviders[chainId] = new JsonRpcProvider(url as string, parseInt(chainId));
+    hydratedProviders[chainId] = new ChainProvider(parseInt(chainId), url);
   });
   return hydratedProviders;
 };


### PR DESCRIPTION
## The Problem
Issue #410: https://github.com/connext/vector/issues/410
<!--- Why is this change required? What problem does it solve? Bug fix or new feature? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## The Solution
The user should be able to specify in their router's config multiple provider addresses which can be used to fallback to.

For fallback functionality, we are leaning on ethersproject FallbackProvider, but have made a custom extending class `ChainProvider` which wraps that functionality but also enforces we are using JsonRpcProvider.

Here we've implemented this change with backwards compatability by using comma-separated values. Example for `chainProviders` in config:
```
{
  "1337": "http://localhost:8545,http://localhost:8546",
  "1338": "http://localhost:8547"
}
```
<!--- Describe the changes you made at a high level -->
<!--- Leave comments on the source diff to draw attention to important low-level specifics -->

TODO: Link change in docs where we've updated the config API.
