### PR TITLE
Dockerfile(s): change curl command to enable multiple retries of curl command

### DIFF
--- a/modules/auth/ops/Dockerfile
+++ b/modules/auth/ops/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /app
 
 RUN apk add --no-cache bash curl g++ gcc git jq make python2 &&\
     npm config set unsafe-perm true &&\
-    curl https://raw.githubusercontent.com/vishnubob/wait-for-it/$(git ls-remote https://github.com/vishnubob/wait-for-it.git refs/heads/master | cut -f1)/wait-for-it.sh > /bin/wait-for &&\
+    until curl https://raw.githubusercontent.com/vishnubob/wait-for-it/$(git ls-remote https://github.com/vishnubob/wait-for-it.git refs/heads/master | cut -f1)/wait-for-it.sh > /bin/wait-for; do sleep 5; done &&\
     chmod +x /bin/wait-for &&\
     rm -rf /var/cache/apk/* /tmp/*
 

--- a/modules/contracts/ops/Dockerfile
+++ b/modules/contracts/ops/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /app
 
 RUN apk add --no-cache bash curl g++ gcc git jq make python2 &&\
     npm config set unsafe-perm true &&\
-    curl https://raw.githubusercontent.com/vishnubob/wait-for-it/$(git ls-remote https://github.com/vishnubob/wait-for-it.git refs/heads/master | cut -f1)/wait-for-it.sh > /bin/wait-for &&\
+    until curl https://raw.githubusercontent.com/vishnubob/wait-for-it/$(git ls-remote https://github.com/vishnubob/wait-for-it.git refs/heads/master | cut -f1)/wait-for-it.sh > /bin/wait-for; do sleep 5; done &&\
     chmod +x /bin/wait-for &&\
     rm -rf /var/cache/apk/* /tmp/*
 

--- a/modules/iframe-app/ops/Dockerfile
+++ b/modules/iframe-app/ops/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /app
 
 RUN apk add --no-cache bash curl g++ gcc git jq make python2 &&\
     npm config set unsafe-perm true &&\
-    curl https://raw.githubusercontent.com/vishnubob/wait-for-it/$(git ls-remote https://github.com/vishnubob/wait-for-it.git refs/heads/master | cut -f1)/wait-for-it.sh > /bin/wait-for &&\
+    until curl https://raw.githubusercontent.com/vishnubob/wait-for-it/$(git ls-remote https://github.com/vishnubob/wait-for-it.git refs/heads/master | cut -f1)/wait-for-it.sh > /bin/wait-for; do sleep 5; done &&\
     chmod +x /bin/wait-for &&\
     rm -rf /var/cache/apk/* /tmp/*
 

--- a/modules/router/ops/Dockerfile
+++ b/modules/router/ops/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /app
 
 RUN apk add --no-cache bash curl g++ gcc git jq make python2 &&\
     npm config set unsafe-perm true &&\
-    curl https://raw.githubusercontent.com/vishnubob/wait-for-it/$(git ls-remote https://github.com/vishnubob/wait-for-it.git refs/heads/master | cut -f1)/wait-for-it.sh > /bin/wait-for &&\
+    until curl https://raw.githubusercontent.com/vishnubob/wait-for-it/$(git ls-remote https://github.com/vishnubob/wait-for-it.git refs/heads/master | cut -f1)/wait-for-it.sh > /bin/wait-for; do sleep 5; done &&\
     chmod +x /bin/wait-for &&\
     rm -rf /var/cache/apk/* /tmp/*
 

--- a/modules/server-node/ops/Dockerfile
+++ b/modules/server-node/ops/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /app
 
 RUN apk add --no-cache bash curl g++ gcc git jq make python2 &&\
     npm config set unsafe-perm true &&\
-    curl https://raw.githubusercontent.com/vishnubob/wait-for-it/$(git ls-remote https://github.com/vishnubob/wait-for-it.git refs/heads/master | cut -f1)/wait-for-it.sh > /bin/wait-for &&\
+    until curl https://raw.githubusercontent.com/vishnubob/wait-for-it/$(git ls-remote https://github.com/vishnubob/wait-for-it.git refs/heads/master | cut -f1)/wait-for-it.sh > /bin/wait-for; do sleep 5; done &&\
     chmod +x /bin/wait-for &&\
     rm -rf /var/cache/apk/* /tmp/*
 

--- a/modules/server-node/ops/arm.Dockerfile
+++ b/modules/server-node/ops/arm.Dockerfile
@@ -16,7 +16,7 @@ COPY ./prisma-binaries-armv8/ /prisma-arm64/
 COPY package.json package.json
 
 RUN chmod +x /prisma-arm64/* &&\
-    curl https://raw.githubusercontent.com/vishnubob/wait-for-it/$(git ls-remote https://github.com/vishnubob/wait-for-it.git refs/heads/master | cut -f1)/wait-for-it.sh > /bin/wait-for &&\
+    until curl https://raw.githubusercontent.com/vishnubob/wait-for-it/$(git ls-remote https://github.com/vishnubob/wait-for-it.git refs/heads/master | cut -f1)/wait-for-it.sh > /bin/wait-for; do sleep 5; done &&\
     chmod +x /bin/wait-for
 
 RUN npm install --production

--- a/modules/test-runner/ops/Dockerfile
+++ b/modules/test-runner/ops/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /app
 
 RUN apk add --no-cache bash curl g++ gcc git jq make python2 &&\
     npm config set unsafe-perm true &&\
-    curl https://raw.githubusercontent.com/vishnubob/wait-for-it/$(git ls-remote https://github.com/vishnubob/wait-for-it.git refs/heads/master | cut -f1)/wait-for-it.sh > /bin/wait-for &&\
+    until curl https://raw.githubusercontent.com/vishnubob/wait-for-it/$(git ls-remote https://github.com/vishnubob/wait-for-it.git refs/heads/master | cut -f1)/wait-for-it.sh > /bin/wait-for; do sleep 5; done &&\
     chmod +x /bin/wait-for &&\
     rm -rf /var/cache/apk/* /tmp/*
 

--- a/ops/builder/Dockerfile
+++ b/ops/builder/Dockerfile
@@ -16,7 +16,7 @@ COPY test.sh /test.sh
 RUN apk add --no-cache bash curl g++ gcc git jq make python2 &&\
     npm config set unsafe-perm true &&\
     npm install -g lerna@$LERNA_VERSION &&\
-    curl https://raw.githubusercontent.com/vishnubob/wait-for-it/$(git ls-remote https://github.com/vishnubob/wait-for-it.git refs/heads/master | cut -f1)/wait-for-it.sh > /bin/wait-for &&\
+    until curl https://raw.githubusercontent.com/vishnubob/wait-for-it/$(git ls-remote https://github.com/vishnubob/wait-for-it.git refs/heads/master | cut -f1)/wait-for-it.sh > /bin/wait-for; do sleep 5; done &&\
     chmod +x /bin/wait-for &&\
     chmod +x /*.sh &&\
     rm -rf /var/cache/apk/* /tmp/*

--- a/ops/proxy/Dockerfile
+++ b/ops/proxy/Dockerfile
@@ -11,7 +11,7 @@ COPY entry.sh /entry.sh
 COPY *.cfg /etc/haproxy/
 
 RUN apk add --no-cache bash ca-certificates certbot curl iputils openssl git &&\
-    curl https://raw.githubusercontent.com/vishnubob/wait-for-it/$(git ls-remote https://github.com/vishnubob/wait-for-it.git refs/heads/master | cut -f1)/wait-for-it.sh > /bin/wait-for &&\
+    until curl https://raw.githubusercontent.com/vishnubob/wait-for-it/$(git ls-remote https://github.com/vishnubob/wait-for-it.git refs/heads/master | cut -f1)/wait-for-it.sh > /bin/wait-for; do sleep 5; done &&\
     chmod +x /bin/wait-for &&\
     chmod +x /*.sh &&\
     rm -rf /var/cache/apk/* /tmp/*


### PR DESCRIPTION
## The Problem
You may have seen this issue (during build of vector with `make`) flying around lately:
```
#9 55.74   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#9 55.74                                  Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:--  0:00:04 --:--:--     0curl: (6) Could not resolve host: raw.githubusercontent.com
------
executor failed running [/bin/sh -c apk add --no-cache bash curl g++ gcc git jq make python2 &&    npm config set unsafe-perm true &&    npm install -g lerna@$LERNA_VERSION &&    curl https://raw.githubusercontent.com/vishnubob/wait-for-it/$(git ls-remote https://github.com/vishnubob/wait-for-it.git refs/heads/master | cut -f1)/wait-for-it.sh > /bin/wait-for &&    chmod +x /bin/wait-for &&    chmod +x /*.sh &&    rm -rf /var/cache/apk/* /tmp/*]: exit code: 6
make: *** [Makefile:265: builder] Error 1
```
Various solutions were 'found' - but no one solution seemed to be settled upon:
- update /etc/docker/daemon.json to have "dns": ["8.8.8.8"]
- for WSL2: update resolv.conf (after setting it to *not* be generated in wsl.conf) to set DNS to 8.8.8.8 manually
- upgrade docker (I did this oops)
- various combinations of updating docker and restarting computer, etc.
Personally, nothing above worked for me until I made the change in this PR.

(FYI: I am on Windows 10 using WSL2 for Ubuntu.)

<!--- Why is this change required? What problem does it solve? Bug fix or new feature? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## The Solution
Ultimately this is a sort of 'brute force' fix where we just retry the curl command.

The DNS issue was happening because the default DNS was unable to resolve `raw.githubusercontent.com` - however, there may be a 'transitional' problem here where it does not retry (or even try at all) using the backup DNS (8.8.8.8 in this case).

**Potential Issue with this Solution**:
- I used `until`, so basically this will keep going until it resolves. It may not resolve if you do not have backup DNS set (8.8.8.8)... or if your internet randomly sputters out, so the user would have to ^C out of the `make` process.

May need to do a set number of retries instead of `until`.
<!--- Describe the changes you made at a high level -->
<!--- Leave comments on the source diff to draw attention to important low-level specifics -->
