### PR TITLE
Add Mumbai Props token info

### DIFF
--- a/modules/utils/src/chains.json
+++ b/modules/utils/src/chains.json
@@ -145,6 +145,10 @@
       "0x0000000000000000000000000000000000001010": {
         "symbol": "MATIC",
         "mainnetEquivalent": "0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0"
+      },
+      "0x48987E8B356e0dE474ddE9Bc10541F8106C88A23": {
+        "symbol": "PROPS",
+        "mainnetEquivalent": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41"
       }
     },
     "rpc": ["https://rpc-mumbai.matic.today", "wss://ws-mumbai.matic.today"],


### PR DESCRIPTION
## The Problem
<!--- Why is this change required? What problem does it solve? Bug fix or new feature? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The Props token is missing data on Mumbai side:
![image](https://user-images.githubusercontent.com/30772943/115007836-185cc680-9eb3-11eb-9b2f-974c37659aa4.png)

@rhlsthrm 
