### PR TITLE
Fix iframe-app-js build by overriding CRA config, adding wasm-loader

### DIFF
--- a/modules/iframe-app/config-overrides.js
+++ b/modules/iframe-app/config-overrides.js
@@ -1,0 +1,29 @@
+// WASM support inspired by https://stackoverflow.com/a/59720645
+
+module.exports = function override(config, env) {
+  const wasmExtensionRegExp = /\.wasm$/;
+
+  config.resolve.extensions.push(".wasm");
+
+  // make file-loader ignore WASM files
+  config.module.rules.forEach((rule) => {
+    (rule.oneOf || []).forEach((oneOf) => {
+      if (oneOf.loader && oneOf.loader.indexOf("file-loader") >= 0) {
+        oneOf.exclude.push(wasmExtensionRegExp);
+      }
+    });
+  });
+
+  // add a dedicated loader for WASM
+  config.module.rules.push({
+    test: wasmExtensionRegExp,
+
+    // necessary to avoid "Module parse failed: magic header not detected" errors;
+    // see https://github.com/pine/arraybuffer-loader/issues/12#issuecomment-390834140
+    type: "javascript/auto",
+
+    use: [{ loader: require.resolve("wasm-loader"), options: {} }],
+  });
+
+  return config;
+};

--- a/modules/iframe-app/package.json
+++ b/modules/iframe-app/package.json
@@ -22,14 +22,16 @@
     "react": "17.0.1",
     "react-dom": "17.0.1",
     "react-scripts": "3.4.3",
-    "typescript": "4.2.4"
+    "react-app-rewired": "2.1.8",
+    "typescript": "4.2.4",
+    "wasm-loader": "1.3.0"
   },
   "scripts": {
-    "start": "BROWSER=none PORT=3030 react-scripts start",
-    "build": "REACT_APP_VECTOR_CONFIG=$(cat \"../../ops/config/browser.default.json\") SKIP_PREFLIGHT_CHECK=true react-scripts build",
-    "build-prod": "SKIP_PREFLIGHT_CHECK=true react-scripts build",
-    "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "start": "BROWSER=none PORT=3030 react-app-rewired start",
+    "build": "REACT_APP_VECTOR_CONFIG=$(cat \"../../ops/config/browser.default.json\") SKIP_PREFLIGHT_CHECK=true react-app-rewired build",
+    "build-prod": "SKIP_PREFLIGHT_CHECK=true react-app-rewired build",
+    "test": "react-app-rewired test",
+    "eject": "react-app-rewired eject"
   },
   "eslintConfig": {
     "extends": [

--- a/modules/utils/src/merkle.spec.ts
+++ b/modules/utils/src/merkle.spec.ts
@@ -27,13 +27,17 @@ describe("generateMerkleTreeData", () => {
       });
   };
 
-  let toFree: merkle.Tree;
+  let toFree: merkle.Tree | undefined;
 
   const getMerkleTreeRoot = (transfers: CoreTransferState[]): string => {
     const data = generateMerkleTreeData(transfers);
     toFree = data.tree;
     return data.root;
   };
+
+  beforeEach(() => {
+    toFree = undefined;
+  });
 
   afterEach(() => {
     if (toFree) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -26988,6 +26988,11 @@
       "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.7.1.tgz",
       "integrity": "sha512-Hesni4s5UkWkwCGJMQGAh71PaLUmKFM60dHvq0zi/vDhhrzuk+4GgNbTXJ12YYQJn6ZKBDNIjYcuQGKudvqrIw=="
     },
+    "long": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
+      "integrity": "sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s="
+    },
     "loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -32006,6 +32011,14 @@
         "raf": "^3.4.1",
         "regenerator-runtime": "^0.13.3",
         "whatwg-fetch": "^3.0.0"
+      }
+    },
+    "react-app-rewired": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/react-app-rewired/-/react-app-rewired-2.1.8.tgz",
+      "integrity": "sha512-wjXPdKPLscA7mn0I1de1NHrbfWdXz4S1ladaGgHVKdn1hTgKK5N6EdGIJM0KrS6bKnJBj7WuqJroDTsPKKr66Q==",
+      "requires": {
+        "semver": "^5.6.0"
       }
     },
     "react-copy-to-clipboard": {
@@ -37156,6 +37169,34 @@
         "loose-envify": "^1.0.0"
       }
     },
+    "wasm-dce": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wasm-dce/-/wasm-dce-1.0.2.tgz",
+      "integrity": "sha512-Fq1+nu43ybsjSnBquLrW/cULmKs61qbv9k8ep13QUe0nABBezMoNAA+j6QY66MW0/eoDVDp1rjXDqQ2VKyS/Xg==",
+      "requires": {
+        "@babel/core": "^7.0.0-beta.39",
+        "@babel/traverse": "^7.0.0-beta.39",
+        "@babel/types": "^7.0.0-beta.39",
+        "babylon": "^7.0.0-beta.39",
+        "webassembly-interpreter": "0.0.30"
+      },
+      "dependencies": {
+        "babylon": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.47.tgz",
+          "integrity": "sha512-+rq2cr4GDhtToEzKFD6KZZMDBXhjFAr9JjPw9pAppZACeEWqNM294j+NdBzkSHYXwzzBmVjZ3nEVJlOhbR2gOQ=="
+        }
+      }
+    },
+    "wasm-loader": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/wasm-loader/-/wasm-loader-1.3.0.tgz",
+      "integrity": "sha512-R4s75XH+o8qM+WaRrAU9S2rbAMDzob18/S3V8R9ZoFpZkPWLAohWWlzWAp1ybeTkOuuku/X1zJtxiV0pBYxZww==",
+      "requires": {
+        "loader-utils": "^1.1.0",
+        "wasm-dce": "^1.0.0"
+      }
+    },
     "watchpack": {
       "version": "1.7.5",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.7.5.tgz",
@@ -37457,6 +37498,21 @@
         "randombytes": "^2.1.0",
         "underscore": "1.9.1",
         "utf8": "3.0.0"
+      }
+    },
+    "webassembly-floating-point-hex-parser": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/webassembly-floating-point-hex-parser/-/webassembly-floating-point-hex-parser-0.1.2.tgz",
+      "integrity": "sha512-TUf1H++8U10+stJbFydnvrpG5Sznz5Rilez/oZlV5zI0C/e4cSxd8rALAJ8VpTvjVWxLmL3SVSJUK6Ap9AoiNg=="
+    },
+    "webassembly-interpreter": {
+      "version": "0.0.30",
+      "resolved": "https://registry.npmjs.org/webassembly-interpreter/-/webassembly-interpreter-0.0.30.tgz",
+      "integrity": "sha512-+Jdy2piEvz9T5j751mOE8+rBO12p+nNW6Fg4kJZ+zP1oUfsm+151sbAbM8AFxWTURmWCGP+r8Lxwfv3pzN1bCQ==",
+      "requires": {
+        "@babel/code-frame": "^7.0.0-beta.36",
+        "long": "^3.2.0",
+        "webassembly-floating-point-hex-parser": "0.1.2"
       }
     },
     "webidl-conversions": {


### PR DESCRIPTION
This PR fixes the iframe-app-js build in #580. I don't know how to _test_ it so I can't say anything about whether it works. It builds, however, and the solution that I got from https://stackoverflow.com/a/59720645 seems to be fairly common for supporting WASM imports in webpack projects. Two more examples:

- https://gist.github.com/GantMan/867e1cfe5d53d132e1dcca8fb7767c98
- https://stackoverflow.com/q/63246203