### PR TITLE
Tx Retry Fixes

### DIFF
--- a/modules/browser-node/src/services/store.ts
+++ b/modules/browser-node/src/services/store.ts
@@ -136,6 +136,10 @@ export class BrowserStore implements IEngineStore, IChainServiceStore {
     this.db = new VectorIndexedDBDatabase(dbName, indexedDB, idbKeyRange);
   }
 
+  getActiveTransactions(): Promise<StoredTransaction[]> {
+    throw new Error("Method not implemented.");
+  }
+
   public static async create(
     publicIdentifer: string,
     log: BaseLogger,

--- a/modules/browser-node/src/services/store.ts
+++ b/modules/browser-node/src/services/store.ts
@@ -136,10 +136,6 @@ export class BrowserStore implements IEngineStore, IChainServiceStore {
     this.db = new VectorIndexedDBDatabase(dbName, indexedDB, idbKeyRange);
   }
 
-  getActiveTransactions(): Promise<StoredTransaction[]> {
-    throw new Error("Method not implemented.");
-  }
-
   public static async create(
     publicIdentifer: string,
     log: BaseLogger,
@@ -311,6 +307,13 @@ export class BrowserStore implements IEngineStore, IChainServiceStore {
 
     const transfers = await collection.toArray();
     return transfers.map(storedTransferToTransferState);
+  }
+
+  async getActiveTransactions(): Promise<StoredTransaction[]> {
+    const tx = await this.db.transactions.filter(tx => {
+      return !!tx.transactionHash && !tx.blockHash && !tx.gasUsed
+    }).toArray();
+    return tx;
   }
 
   async saveTransactionResponse(

--- a/modules/contracts/src.ts/services/ethService.spec.ts
+++ b/modules/contracts/src.ts/services/ethService.spec.ts
@@ -573,6 +573,6 @@ describe("ethService", () => {
   });
 
   describe("revitalizeTxs", () => {
-    it("should start monitoring active txs", async () => {};
+    it("should start monitoring active txs", async () => {});
   });
 });

--- a/modules/contracts/src.ts/services/ethService.spec.ts
+++ b/modules/contracts/src.ts/services/ethService.spec.ts
@@ -571,4 +571,8 @@ describe("ethService", () => {
       assertResult(result, false);
     });
   });
+
+  describe("revitalizeTxs", () => {
+    it("should start monitoring active txs", async () => {};
+  });
 });

--- a/modules/contracts/src.ts/services/ethService.spec.ts
+++ b/modules/contracts/src.ts/services/ethService.spec.ts
@@ -420,7 +420,7 @@ describe.only("ethService unit test", () => {
     });
 
     it("errors if transaction is confirmed", async () => {
-      provider1337.getTransaction.resolves({ confirmations: 1 } as any);
+      stub(ethService, "getTxResponseFromHash").resolves(Result.ok({ response: txResponse, receipt: txReceipt }));
       const result = await ethService.speedUpTx(1337, minTx);
       assertResult(result, true, ChainError.reasons.TxAlreadyMined);
     });

--- a/modules/contracts/src.ts/services/ethService.spec.ts
+++ b/modules/contracts/src.ts/services/ethService.spec.ts
@@ -490,7 +490,7 @@ describe.only("ethService unit test", () => {
     });
   });
 
-  describe.only("sendAndConfirmTx", () => {
+  describe("sendAndConfirmTx", () => {
     beforeEach(() => {
       waitForConfirmation = stub(ethService, "waitForConfirmation");
     });
@@ -573,8 +573,9 @@ describe.only("ethService unit test", () => {
       assertResult(result, true, "Booooo");
     });
 
-    it("happy: saves responses", async () => {
-      const result = await ethService.sendAndConfirmTx(AddressZero, 111, "allowance", async () => {
+    it("happy: saves responses if confirmation happens on first loop", async () => {
+      waitForConfirmation.resolves(txReceipt);
+      const result = await ethService.sendAndConfirmTx(AddressZero, 1337, "allowance", async () => {
         return _txResponse;
       });
       expect(storeMock.saveTransactionResponse.callCount).eq(1);

--- a/modules/contracts/src.ts/services/ethService.spec.ts
+++ b/modules/contracts/src.ts/services/ethService.spec.ts
@@ -55,7 +55,7 @@ const assertResult = (result: Result<any>, isError: boolean, unwrappedVal?: any)
   }
 };
 
-const _txResponse = {
+const txResponse = {
   chainId: 1337,
   confirmations: 1,
   data: "0x",
@@ -75,12 +75,12 @@ const txReceipt: TransactionReceipt = {
   confirmations: 1,
   contractAddress: mkAddress("0xa"),
   cumulativeGasUsed: BigNumber.from(21000),
-  from: _txResponse.from,
+  from: txResponse.from,
   gasUsed: BigNumber.from(21000),
   logs: [],
   logsBloom: "0x",
   to: mkAddress("0xbbb"),
-  transactionHash: _txResponse.hash,
+  transactionHash: txResponse.hash,
   transactionIndex: 1,
   status: 1,
 };
@@ -96,7 +96,7 @@ describe.only("ethService unit test", () => {
     (signer as any)._isSigner = true;
 
     const _provider = createStubInstance(JsonRpcProvider);
-    _provider.getTransaction.resolves(_txResponse);
+    _provider.getTransaction.resolves(txResponse);
     provider1337 = _provider;
     provider1338 = _provider;
     (signer as any).provider = provider1337;
@@ -450,7 +450,7 @@ describe.only("ethService unit test", () => {
         channelState.networkContext.chainId,
         "allowance",
         () => {
-          return Promise.resolve(_txResponse);
+          return Promise.resolve(txResponse);
         },
       );
       assertResult(result, true, ChainError.reasons.NotEnoughFunds);
@@ -473,7 +473,7 @@ describe.only("ethService unit test", () => {
         channelState.networkContext.chainId,
         "allowance",
         () => {
-          return Promise.resolve(_txResponse);
+          return Promise.resolve(txResponse);
         },
       );
       assertResult(result, false, txReceipt);
@@ -485,7 +485,7 @@ describe.only("ethService unit test", () => {
         channelState.networkContext.chainId,
         "allowance",
         () => {
-          return Promise.resolve(_txResponse);
+          return Promise.resolve(txResponse);
         },
       );
       assertResult(result, false, txReceipt);
@@ -540,18 +540,18 @@ describe.only("ethService unit test", () => {
     it("if receipt status == 0, saves response with error", async () => {
       waitForConfirmation.resolves({ ...txReceipt, status: 0 });
       const result = await ethService.sendAndConfirmTx(AddressZero, 1337, "allowance", async () => {
-        return _txResponse;
+        return txResponse;
       });
       expect(storeMock.saveTransactionResponse.callCount).eq(1);
       const saveTransactionResponseCall = storeMock.saveTransactionResponse.getCall(0);
       expect(saveTransactionResponseCall.args[0]).eq(AddressZero);
       expect(saveTransactionResponseCall.args[1]).eq("allowance");
-      expect(saveTransactionResponseCall.args[2]).deep.eq(_txResponse);
+      expect(saveTransactionResponseCall.args[2]).deep.eq(txResponse);
 
       expect(storeMock.saveTransactionFailure.callCount).eq(1);
       const saveTransactionFailureCall = storeMock.saveTransactionFailure.getCall(0);
       expect(saveTransactionFailureCall.args[0]).eq(AddressZero);
-      expect(saveTransactionFailureCall.args[1]).eq(_txResponse.hash);
+      expect(saveTransactionFailureCall.args[1]).eq(txResponse.hash);
       expect(saveTransactionFailureCall.args[2]).eq("Tx reverted");
       assertResult(result, true, ChainError.reasons.TxReverted);
     });
@@ -560,38 +560,38 @@ describe.only("ethService unit test", () => {
       const error = new Error("Booooo");
       waitForConfirmation.rejects(error);
       const result = await ethService.sendAndConfirmTx(AddressZero, 1337, "allowance", async () => {
-        return _txResponse;
+        return txResponse;
       });
       expect(storeMock.saveTransactionResponse.callCount).eq(1);
       const saveTransactionResponseCall = storeMock.saveTransactionResponse.getCall(0);
       expect(saveTransactionResponseCall.args[0]).eq(AddressZero);
       expect(saveTransactionResponseCall.args[1]).eq("allowance");
-      expect(saveTransactionResponseCall.args[2]).deep.eq(_txResponse);
+      expect(saveTransactionResponseCall.args[2]).deep.eq(txResponse);
 
       expect(storeMock.saveTransactionFailure.callCount).eq(1);
       const saveTransactionFailureCall = storeMock.saveTransactionFailure.getCall(0);
       expect(saveTransactionFailureCall.args[0]).eq(AddressZero);
-      expect(saveTransactionFailureCall.args[1]).eq(_txResponse.hash);
+      expect(saveTransactionFailureCall.args[1]).eq(txResponse.hash);
       expect(saveTransactionFailureCall.args[2]).eq("Booooo");
       assertResult(result, true, "Booooo");
     });
 
     it("retries transaction with higher gas price", async () => {
-      const newTx = { ..._txResponse, hash: mkHash("0xddd") }; // change hash to simulate higher gas and new hash
+      const newTx = { ...txResponse, hash: mkHash("0xddd") }; // change hash to simulate higher gas and new hash
       const newReceipt = { ...txReceipt, transactionHash: newTx.hash };
       waitForConfirmation.onFirstCall().rejects(new ChainError(ChainError.retryableTxErrors.ConfirmationTimeout));
       signer.sendTransaction.resolves(newTx); // new tx with higher gas
       waitForConfirmation.onSecondCall().resolves(newReceipt);
 
       const result = await ethService.sendAndConfirmTx(AddressZero, 1337, "allowance", async () => {
-        return _txResponse;
+        return txResponse;
       });
 
       expect(storeMock.saveTransactionResponse.callCount).eq(2);
       const saveTransactionResponseCall = storeMock.saveTransactionResponse.getCall(0);
       expect(saveTransactionResponseCall.args[0]).eq(AddressZero);
       expect(saveTransactionResponseCall.args[1]).eq("allowance");
-      expect(saveTransactionResponseCall.args[2]).deep.eq(_txResponse);
+      expect(saveTransactionResponseCall.args[2]).deep.eq(txResponse);
 
       const saveTransactionResponseCall2 = storeMock.saveTransactionResponse.getCall(1);
       expect(saveTransactionResponseCall2.args[0]).eq(AddressZero);
@@ -610,19 +610,19 @@ describe.only("ethService unit test", () => {
       waitForConfirmation.onFirstCall().rejects(new ChainError(ChainError.retryableTxErrors.ConfirmationTimeout));
 
       const result = await ethService.sendAndConfirmTx(AddressZero, 1337, "allowance", async () => {
-        return _txResponse;
+        return txResponse;
       });
 
       expect(storeMock.saveTransactionResponse.callCount).eq(1);
       const saveTransactionResponseCall = storeMock.saveTransactionResponse.getCall(0);
       expect(saveTransactionResponseCall.args[0]).eq(AddressZero);
       expect(saveTransactionResponseCall.args[1]).eq("allowance");
-      expect(saveTransactionResponseCall.args[2]).deep.eq(_txResponse);
+      expect(saveTransactionResponseCall.args[2]).deep.eq(txResponse);
 
       expect(storeMock.saveTransactionFailure.callCount).eq(1);
       const saveTransactionFailureCall = storeMock.saveTransactionFailure.getCall(0);
       expect(saveTransactionFailureCall.args[0]).eq(AddressZero);
-      expect(saveTransactionFailureCall.args[1]).eq(_txResponse.hash);
+      expect(saveTransactionFailureCall.args[1]).eq(txResponse.hash);
       expect(saveTransactionFailureCall.args[2]).eq(ChainError.reasons.MaxGasPriceReached);
 
       assertResult(result, true, ChainError.reasons.MaxGasPriceReached);
@@ -631,19 +631,43 @@ describe.only("ethService unit test", () => {
     it("happy: saves responses if confirmation happens on first loop", async () => {
       waitForConfirmation.resolves(txReceipt);
       const result = await ethService.sendAndConfirmTx(AddressZero, 1337, "allowance", async () => {
-        return _txResponse;
+        return txResponse;
       });
       expect(storeMock.saveTransactionResponse.callCount).eq(1);
       const saveTransactionResponseCall = storeMock.saveTransactionResponse.getCall(0);
       expect(saveTransactionResponseCall.args[0]).eq(AddressZero);
       expect(saveTransactionResponseCall.args[1]).eq("allowance");
-      expect(saveTransactionResponseCall.args[2]).deep.eq(_txResponse);
+      expect(saveTransactionResponseCall.args[2]).deep.eq(txResponse);
 
       expect(storeMock.saveTransactionReceipt.callCount).eq(1);
       const saveTransactionReceiptCall = storeMock.saveTransactionReceipt.getCall(0);
       expect(saveTransactionReceiptCall.args[0]).eq(AddressZero);
 
-      assertResult(result, false);
+      assertResult(result, false, txReceipt);
+    });
+  });
+
+  describe("waitForConfirmation", () => {
+    it("should return an error if there is no provider for chain", async () => {
+      await expect(ethService.waitForConfirmation(111, txResponse)).to.eventually.be.rejectedWith(
+        ChainError.reasons.ProviderNotFound,
+      );
+    });
+
+    it("should wait for the required amount of confirmations", async () => {
+      provider1337.send.onFirstCall().resolves({ ...txReceipt, confirmations: 0 });
+      provider1337.send.onSecondCall().resolves({ ...txReceipt, confirmations: 0 });
+      provider1337.send.onThirdCall().resolves(txReceipt);
+      const res = await ethService.waitForConfirmation(1337, txResponse);
+      expect(res).to.deep.eq(txReceipt);
+      expect(provider1337.send.callCount).to.eq(3);
+    });
+
+    it("should error with a timeout error if it is past the confirmation time", async () => {
+      provider1337.send.onThirdCall().resolves(undefined);
+      await expect(ethService.waitForConfirmation(1337, txResponse)).to.eventually.be.rejectedWith(
+        ChainError.retryableTxErrors.ConfirmationTimeout,
+      );
     });
   });
 

--- a/modules/contracts/src.ts/services/ethService.spec.ts
+++ b/modules/contracts/src.ts/services/ethService.spec.ts
@@ -486,25 +486,25 @@ describe("ethService", () => {
     it("if txFn returns undefined, returns undefined", async () => {
       const result = await ethService.sendTxAndParseResponse(AddressZero, 111, "allowance", async () => {
         return undefined;
-      });
+      }, BigNumber.from(10_000));
       assertResult(result, false, undefined);
     });
 
     it("if txFn errors, returns error", async () => {
       const result = await ethService.sendTxAndParseResponse(AddressZero, 111, "allowance", async () => {
         throw new Error("Boooo");
-      });
+      }, BigNumber.from(10_000));
       assertResult(result, true, "Boooo");
     });
 
     it("if txFn errors, with not enough funds, return special error", async () => {
       const result = await ethService.sendTxAndParseResponse(AddressZero, 111, "allowance", async () => {
         throw new Error("sender doesn't have enough funds");
-      });
+      }, BigNumber.from(10_000));
       assertResult(result, true, ChainError.reasons.NotEnoughFunds);
     });
 
-    it("if receipt status = 0, saves response with error", async () => {
+    it("if receipt status == 0, saves response with error", async () => {
       const t = {
         ..._txResponse,
         wait: async () => {

--- a/modules/contracts/src.ts/services/ethService.spec.ts
+++ b/modules/contracts/src.ts/services/ethService.spec.ts
@@ -87,7 +87,7 @@ const txReceipt: TransactionReceipt = {
 };
 
 const { log } = getTestLoggers("ethService");
-describe.only("ethService unit test", () => {
+describe("ethService unit test", () => {
   beforeEach(() => {
     // eth service deps
     storeMock = createStubInstance(MemoryStoreService);

--- a/modules/contracts/src.ts/services/ethService.spec.ts
+++ b/modules/contracts/src.ts/services/ethService.spec.ts
@@ -613,14 +613,12 @@ describe.only("ethService unit test", () => {
         return _txResponse;
       });
 
-      console.log("storeMock.saveTransactionResponse.callCount: ", storeMock.saveTransactionResponse.callCount);
       expect(storeMock.saveTransactionResponse.callCount).eq(1);
       const saveTransactionResponseCall = storeMock.saveTransactionResponse.getCall(0);
       expect(saveTransactionResponseCall.args[0]).eq(AddressZero);
       expect(saveTransactionResponseCall.args[1]).eq("allowance");
       expect(saveTransactionResponseCall.args[2]).deep.eq(_txResponse);
 
-      console.log("storeMock.saveTransactionFailure.callCount: ", storeMock.saveTransactionFailure.callCount);
       expect(storeMock.saveTransactionFailure.callCount).eq(1);
       const saveTransactionFailureCall = storeMock.saveTransactionFailure.getCall(0);
       expect(saveTransactionFailureCall.args[0]).eq(AddressZero);

--- a/modules/contracts/src.ts/services/ethService.ts
+++ b/modules/contracts/src.ts/services/ethService.ts
@@ -94,6 +94,7 @@ export class EthereumChainService extends EthereumChainReader implements IVector
     });
 
     // TODO: Check to see which tx's are still active / unresolved, and resolve them.
+    this.revitalizeTxs();
   }
 
   /// Check to see if any txs were left in an unfinished state. This should only execute on

--- a/modules/contracts/src.ts/services/ethService.ts
+++ b/modules/contracts/src.ts/services/ethService.ts
@@ -599,6 +599,9 @@ export class EthereumChainService extends EthereumChainReader implements IVector
   ): Promise<Result<TransactionResponseWithResult | undefined, ChainError>> {
     try {
       const response = await this.queue.add(async () => {
+        // TODO: We should raise gas price if the waitForConfirmation below "times out" essentially.
+        // Default timeout should be around ~15 sec.
+        // Raise gas price in intervals of GAS_BUMP_PERCENT
         const gasPriceRes = await this.getGasPrice(chainId);
         if (gasPriceRes.isError) {
           throw gasPriceRes.getError()!;

--- a/modules/contracts/src.ts/services/ethService.ts
+++ b/modules/contracts/src.ts/services/ethService.ts
@@ -634,7 +634,8 @@ export class EthereumChainService extends EthereumChainReader implements IVector
           reason,
         });
   
-        return await this.waitForConfirmation(channelAddress, chainId, reason, response);
+        await this.waitForConfirmation(channelAddress, chainId, reason, response);
+        return response;
       });
 
       if (!response) {

--- a/modules/contracts/src.ts/services/ethService.ts
+++ b/modules/contracts/src.ts/services/ethService.ts
@@ -104,8 +104,29 @@ export class EthereumChainService extends EthereumChainReader implements IVector
     const activeTransactions = await this.store.getActiveTransactions();
     // TODO: Should we filter out "stale" tx's (older than a specified elapsed time)?
     activeTransactions.forEach(t => {
-      // TODO: Resend tx.
-      // this.sendTxWithRetries(t.channelAddress, t.chainId, t.reason, ...)
+      // TODO: Wait for confirmation from here - will handle resend as needed.
+      // this.waitForConfirmation(t.channelAddress, t.chainId, t.reason, {
+      //   hash: t.transactionHash,
+      //   reason: t.reason,
+        
+      //   to: t.to,
+      //   from: t.from,
+      //   data: t.data,
+      //   value: t.value,
+      //   chainId: t.chainId,
+      //   nonce: t.nonce,
+      //   gasLimit: t.gasLimit,
+      //   gasPrice: t.gasPrice,
+      //   timestamp: t.timestamp,
+      //   raw: t.raw,
+      //   blockHash: t.blockHash,
+      //   blockNumber: t.blockNumber,
+      //     // channel: {
+      //     //   connect: {
+      //     //     channelAddress,
+      //     //   },
+      //     // },
+      //   } as TransactionResponse)
     });
   }
 

--- a/modules/contracts/src.ts/services/ethService.ts
+++ b/modules/contracts/src.ts/services/ethService.ts
@@ -349,6 +349,8 @@ export class EthereumChainService extends EthereumChainReader implements IVector
       let error = e;
       if (e.message.includes("sender doesn't have enough funds")) {
         error = new ChainError(ChainError.reasons.NotEnoughFunds);
+      } else {
+        this.log.error({ channelAddress, reason, error: jsonifyError(e) }, "Failed to do tx");
       }
       return Result.fail(error);
     }

--- a/modules/contracts/src.ts/services/ethService.ts
+++ b/modules/contracts/src.ts/services/ethService.ts
@@ -215,7 +215,6 @@ export class EthereumChainService extends EthereumChainReader implements IVector
     const method = "sendTxWithRetries";
     const methodId = getRandomBytes32();
     const errors = [];
-    let receipt: TransactionResponse | null = null;
     let currentGasPrice: BigNumber;
     const price = await this.getGasPrice(chainId);
     if (price.isError) {
@@ -228,7 +227,7 @@ export class EthereumChainService extends EthereumChainReader implements IVector
       // We should raise gas price if the confirmation of tx below "times out" essentially.
       // Default timeout should be around ~15 sec. (GAS_BUMP_THRESHOLD)
       // We should raise our gas price for any subsuquent attempt.
-      if (errors[attempt - 1].message === ChainError.retryableTxErrors.ConfirmationTimeout) {
+      if (errors.length > 0 && errors[attempt - 1].message === ChainError.retryableTxErrors.ConfirmationTimeout) {
         // Scale up gas by percentage as specified by GAS_BUMP_PERCENT.
         currentGasPrice = currentGasPrice.add(currentGasPrice.mul(GAS_BUMP_PERCENT));
       }

--- a/modules/contracts/src.ts/services/ethService.ts
+++ b/modules/contracts/src.ts/services/ethService.ts
@@ -428,7 +428,6 @@ export class EthereumChainService extends EthereumChainReader implements IVector
       }
 
       const receipt = await queuedResponse.completed;
-      console.log("queuedResponse.completed receipt: ", receipt);
       if (receipt.status === 0) {
         return Result.fail(new ChainError(ChainError.reasons.TxReverted, { receipt, method, methodId }));
       }

--- a/modules/contracts/src.ts/services/ethService.ts
+++ b/modules/contracts/src.ts/services/ethService.ts
@@ -100,11 +100,8 @@ export class EthereumChainService extends EthereumChainReader implements IVector
     this.revitalizeTxs();
   }
 
-  private getSigner(chainId: number): Signer {
+  private getSigner(chainId: number): Signer | undefined {
     const signer = this.signers.get(chainId);
-    if (!signer?._isSigner) {
-      throw new ChainError(ChainError.reasons.SignerNotFound);
-    }
     return signer;
   }
 

--- a/modules/contracts/src.ts/services/ethService.ts
+++ b/modules/contracts/src.ts/services/ethService.ts
@@ -352,13 +352,13 @@ export class EthereumChainService extends EthereumChainReader implements IVector
         // completed callback should always return a receipt and abstract the waiting and bumping of gas prices
 
         // use a promise here so that the whole confirmation is not held up in the queue
-        let tryNumber = 0;
         const completed = new Promise<TransactionReceipt>(async (resolve, reject) => {
+          let tryNumber = 0;
           while (true) {
             try {
-              // Wait for confirmation.
-              this.log.info({ tryNumber }, "Waiting for tx");
               tryNumber += 1;
+              this.log.info({ tryNumber }, "Waiting for tx");
+              // Wait for confirmation.
               const receipt = await this.waitForConfirmation(chainId, response!);
               // Handle receipt / store updates to complete tx.
               if (receipt.status === 0) {

--- a/modules/contracts/src.ts/services/ethService.ts
+++ b/modules/contracts/src.ts/services/ethService.ts
@@ -358,6 +358,7 @@ export class EthereumChainService extends EthereumChainReader implements IVector
             try {
               // Wait for confirmation.
               this.log.info({ tryNumber }, "Waiting for tx");
+              tryNumber += 1;
               const receipt = await this.waitForConfirmation(chainId, response!);
               // Handle receipt / store updates to complete tx.
               if (receipt.status === 0) {

--- a/modules/contracts/src.ts/services/ethService.ts
+++ b/modules/contracts/src.ts/services/ethService.ts
@@ -178,10 +178,15 @@ export class EthereumChainService extends EthereumChainReader implements IVector
     const method = "speedUpTx";
     const methodId = getRandomBytes32();
     this.log.info({ method, methodId, transactionHash: tx.transactionHash }, "Method started");
-    const signer = this.getSigner(chainId);
-
-    // Make sure tx is not mined already
-    const receipt = await this.getTxReceiptFromHash(chainId, tx);
+    let signer: Signer;
+    let receipt: TransactionResponse | null;
+    try {
+      signer = this.getSigner(chainId);
+      // Make sure tx is not mined already
+      receipt = await this.getTxReceiptFromHash(chainId, tx);
+    } catch (e) {
+      return Result.fail(e);
+    }
 
     // Safe to retry sending
     return this.sendTxWithRetries(tx.to, chainId, TransactionReason.speedUpTransaction, async (gasPrice: BigNumber) => {

--- a/modules/contracts/src.ts/services/ethService.ts
+++ b/modules/contracts/src.ts/services/ethService.ts
@@ -41,7 +41,6 @@ import { ChannelFactory, VectorChannel } from "../artifacts";
 
 import { EthereumChainReader } from "./ethReader";
 import { parseUnits } from "ethers/lib/utils";
-import { ethers } from "hardhat";
 
 export const EXTRA_GAS = 50_000;
 // The amount of time (ms) to wait before a confirmation polling period times out,
@@ -318,7 +317,7 @@ export class EthereumChainService extends EthereumChainReader implements IVector
           reason,
         });
   
-        await this.waitForConfirmation(channelAddress, reason, response);
+        await this.waitForConfirmation(channelAddress, chainId, reason, response);
         return response;
       });
 
@@ -353,6 +352,7 @@ export class EthereumChainService extends EthereumChainReader implements IVector
 
   private async waitForConfirmation(
     channelAddress: string,
+    chainId: number,
     reason: TransactionReason,
     response: TransactionResponse,
   ): Promise<TransactionReceipt | undefined> {
@@ -361,7 +361,7 @@ export class EthereumChainService extends EthereumChainReader implements IVector
       // TODO: This should be replaced with a polling method (?)
       // TODO: If we're polling here, we shouldn't be awaiting a receipt, but checking to see if it's available
       // (i.e. it's been confirmed / mined).
-      return await ethers.provider.getTransactionReceipt(response.hash);
+      return await this.chainProviders[chainId].getTransactionReceipt(response.hash);
       // TODO: If the tx has not yet been mined, return undefined.
       // return undefined;
     }

--- a/modules/contracts/src.ts/services/ethService.ts
+++ b/modules/contracts/src.ts/services/ethService.ts
@@ -356,6 +356,7 @@ export class EthereumChainService extends EthereumChainReader implements IVector
                   gasPrice = gasPrice.add(gasPrice.mul(GAS_BUMP_PERCENT));
 
                   // TODO: resend exact same tx with the same nonce, overwrite the response in the DB
+                  // make sure new gasPrice is being saved
                 } else {
                   // If we get any other error here, we classify this event as a tx failure and break out of the loop.
                   this.log.error({ method: "sendTxAndParseResponse", error: jsonifyError(e) }, "Transaction reverted.");

--- a/modules/contracts/src.ts/tests/integration/ethService.spec.ts
+++ b/modules/contracts/src.ts/tests/integration/ethService.spec.ts
@@ -8,18 +8,15 @@ import {
   expect,
   getRandomAddress,
   getRandomBytes32,
-  hashCoreTransferState,
   hashTransferState,
   MemoryStoreService,
   generateMerkleTreeData,
 } from "@connext/vector-utils";
 import { AddressZero } from "@ethersproject/constants";
 import { Contract } from "@ethersproject/contracts";
-import { keccak256 } from "@ethersproject/keccak256";
 import { parseEther } from "@ethersproject/units";
 import { BigNumber } from "@ethersproject/bignumber";
 import { deployments } from "hardhat";
-import { MerkleTree } from "merkletreejs";
 
 import { alice, bob, chainIdReq, logger, provider, rando } from "../../constants";
 import { advanceBlocktime, getContract, createChannel } from "../../utils";
@@ -161,5 +158,9 @@ describe("EthereumChainService", function () {
     );
     const res = await bobChainService.sendDefundTransferTx(transferState);
     expect(res.getValue()).to.be.ok;
+  });
+
+  describe("revitalizeTxs", () => {
+    it("should start monitoring active txs", async () => {});
   });
 });

--- a/modules/contracts/src.ts/tests/integration/ethService.spec.ts
+++ b/modules/contracts/src.ts/tests/integration/ethService.spec.ts
@@ -23,7 +23,7 @@ import { advanceBlocktime, getContract, createChannel } from "../../utils";
 
 import { EthereumChainService } from "../../services/ethService";
 
-describe("EthereumChainService", function () {
+describe("ethService integration", function () {
   this.timeout(120_000);
   const aliceSigner = new ChannelSigner(alice.privateKey);
   const bobSigner = new ChannelSigner(bob.privateKey);

--- a/modules/contracts/src.ts/tests/integration/ethService.spec.ts
+++ b/modules/contracts/src.ts/tests/integration/ethService.spec.ts
@@ -159,8 +159,4 @@ describe("ethService integration", function () {
     const res = await bobChainService.sendDefundTransferTx(transferState);
     expect(res.getValue()).to.be.ok;
   });
-
-  describe("revitalizeTxs", () => {
-    it("should start monitoring active txs", async () => {});
-  });
 });

--- a/modules/engine/src/index.ts
+++ b/modules/engine/src/index.ts
@@ -1308,6 +1308,16 @@ export class VectorEngine implements IVectorEngine {
       return Result.fail(disputeRes.getError()!);
     }
 
+    // save the dispute
+    const dispute = await this.chainService.getChannelDispute(state.channelAddress, state.networkContext.chainId);
+    if (!dispute.isError && !!dispute.getValue()) {
+      try {
+        await this.store.saveChannelDispute(state.channelAddress, dispute.getValue()!);
+      } catch (e) {
+        this.logger.error({ ...jsonifyError(e) }, "Failed to save channel dispute");
+      }
+    }
+
     return Result.ok({ transactionHash: disputeRes.getValue().transactionHash });
   }
 

--- a/modules/engine/src/index.ts
+++ b/modules/engine/src/index.ts
@@ -669,13 +669,8 @@ export class VectorEngine implements IVectorEngine {
       );
       return setupRes;
     }
-    const tx = deployRes.getValue();
-    this.logger.info({ chainId: channel.networkContext.chainId, hash: tx.hash }, "Deploy tx broadcast");
-    const receipt = await tx.completed();
-    if (receipt.isError) {
-      return Result.fail(receipt.getError()!);
-    }
-    this.logger.debug({ chainId: channel.networkContext.chainId, hash: tx.hash }, "Deploy tx mined");
+    const receipt = deployRes.getValue();
+    this.logger.debug({ chainId: channel.networkContext.chainId, hash: receipt.transactionHash }, "Deploy tx mined");
     this.logger.info(
       { result: setupRes.isError ? jsonifyError(setupRes.getError()!) : setupRes.getValue(), method, methodId },
       "Method complete",
@@ -1313,27 +1308,7 @@ export class VectorEngine implements IVectorEngine {
       return Result.fail(disputeRes.getError()!);
     }
 
-    // register saving callback
-    disputeRes
-      .getValue()
-      .completed(getConfirmationsForChain(state.networkContext.chainId))
-      .then(async (receipt) => {
-        if (receipt.isError) {
-          return;
-        }
-        // save the dispute
-        // TODO: make this event driven
-        const dispute = await this.chainService.getChannelDispute(state.channelAddress, state.networkContext.chainId);
-        if (!dispute.isError && !!dispute.getValue()) {
-          try {
-            await this.store.saveChannelDispute(state.channelAddress, dispute.getValue()!);
-          } catch (e) {
-            this.logger.error({ ...jsonifyError(e) }, "Failed to save channel dispute");
-          }
-        }
-      });
-
-    return Result.ok({ transactionHash: disputeRes.getValue().hash });
+    return Result.ok({ transactionHash: disputeRes.getValue().transactionHash });
   }
 
   private async defund(
@@ -1369,7 +1344,7 @@ export class VectorEngine implements IVectorEngine {
       return Result.fail(disputeRes.getError()!);
     }
 
-    return Result.ok({ transactionHash: disputeRes.getValue().hash });
+    return Result.ok({ transactionHash: disputeRes.getValue().transactionHash });
   }
 
   private async getTransferDispute(
@@ -1428,7 +1403,7 @@ export class VectorEngine implements IVectorEngine {
     if (disputeRes.isError) {
       return Result.fail(disputeRes.getError()!);
     }
-    return Result.ok({ transactionHash: disputeRes.getValue().hash });
+    return Result.ok({ transactionHash: disputeRes.getValue().transactionHash });
   }
 
   private async defundTransfer(
@@ -1470,7 +1445,7 @@ export class VectorEngine implements IVectorEngine {
     if (defundRes.isError) {
       return Result.fail(defundRes.getError()!);
     }
-    return Result.ok({ transactionHash: defundRes.getValue().hash });
+    return Result.ok({ transactionHash: defundRes.getValue().transactionHash });
   }
 
   private async exit(
@@ -1516,7 +1491,7 @@ export class VectorEngine implements IVectorEngine {
       );
       results.push({
         assetId,
-        transactionHash: result.isError ? undefined : result.getValue().hash,
+        transactionHash: result.isError ? undefined : result.getValue().transactionHash,
         error: result.isError ? jsonifyError(result.getError()!) : undefined,
       });
     }

--- a/modules/engine/src/listeners.ts
+++ b/modules/engine/src/listeners.ts
@@ -990,7 +990,7 @@ export async function handleWithdrawalTransferResolution(
     return;
   }
   const tx = withdrawalResponse.getValue();
-  commitment!.addTransaction(tx.hash);
+  commitment!.addTransaction(tx.transactionHash);
   await store.saveWithdrawalCommitment(transferId, commitment!.toJson());
 
   // alice submitted her own withdrawal, post to evt
@@ -999,15 +999,9 @@ export async function handleWithdrawalTransferResolution(
     bobIdentifier,
     channelAddress,
     transferId,
-    transactionHash: tx.hash,
+    transactionHash: tx.transactionHash,
   });
-  logger.info({ transactionHash: tx.hash }, "Submitted withdraw tx");
-  const receipt = await tx.completed();
-  if (receipt.isError) {
-    logger.error({ method, receipt: receipt.getError()! }, "Withdraw tx reverted");
-  } else {
-    logger.info({ method, transactionHash: receipt.getValue().transactionHash }, "Withdraw tx mined, completed");
-  }
+  logger.info({ transactionHash: tx.transactionHash }, "Submitted withdraw tx");
 }
 
 export const isWithdrawTransfer = async (
@@ -1132,7 +1126,7 @@ export const resolveWithdrawal = async (
     // IFF the withdrawal was successfully submitted, resolve the transfer
     // with the transactionHash in the meta
     if (!withdrawalResponse.isError) {
-      transactionHash = withdrawalResponse.getValue()!.hash;
+      transactionHash = withdrawalResponse.getValue()!.transactionHash;
       logger.info({ method, transactionHash }, "Submitted tx");
       // Post to reconciliation evt on submission
       evts[WITHDRAWAL_RECONCILED_EVENT].post({

--- a/modules/engine/src/testing/listeners.spec.ts
+++ b/modules/engine/src/testing/listeners.spec.ts
@@ -122,8 +122,7 @@ describe(testName, () => {
     chainService = Sinon.createStubInstance(VectorChainService, {
       sendWithdrawTx: Promise.resolve(
         Result.ok({
-          hash: withdrawTransactionHash,
-          wait: () => Promise.resolve({ transactionHash: withdrawTransactionHash }),
+          transactionHash: withdrawTransactionHash,
         }),
       ) as any,
       getRegisteredTransferByName: Promise.resolve(Result.ok(withdrawRegisteredInfo)),

--- a/modules/router/src/services/collateral.ts
+++ b/modules/router/src/services/collateral.ts
@@ -376,33 +376,8 @@ export const requestCollateral = async (
         ),
       );
     }
-
-    const tx = txRes.getValue();
-    logger.info({ method, methodId, txHash: tx.txHash }, "Submitted deposit tx");
-    const receipt = await waitForTransaction(
-      provider,
-      tx.txHash,
-      getConfirmationsForChain(channel.networkContext.chainId),
-      // IFF non-mainnet, shouldnt take longer than 5min
-      channel.networkContext.chainId === 1 ? undefined : 600_000,
-    );
-    if (receipt.isError) {
-      return Result.fail(
-        new CollateralError(
-          CollateralError.reasons.UnableToCollateralize,
-          channel.channelAddress,
-          assetId,
-          profile,
-          requestedAmount,
-          {
-            error: jsonifyError(receipt.getError()!),
-            transactionHash: tx.txHash,
-          },
-        ),
-      );
-    }
-    logger.info({ method, methodId, txHash: tx.txHash }, "Tx mined");
-    logger.debug({ method, methodId, txHash: tx.txHash, logs: receipt.getValue().logs }, "Tx mined");
+    const receipt = txRes.getValue();
+    logger.info({ method, methodId, txHash: receipt.txHash }, "Tx mined");
   } else {
     logger.info(
       {

--- a/modules/router/src/services/collateral.ts
+++ b/modules/router/src/services/collateral.ts
@@ -5,10 +5,8 @@ import {
   NodeResponses,
   IVectorChainReader,
   jsonifyError,
-  getConfirmationsForChain,
 } from "@connext/vector-types";
 import { getBalanceForAssetId, getRandomBytes32, getParticipant } from "@connext/vector-utils";
-import { waitForTransaction } from "@connext/vector-contracts";
 import { getAddress } from "@ethersproject/address";
 import { BigNumber } from "@ethersproject/bignumber";
 import { BaseLogger } from "pino";
@@ -16,7 +14,6 @@ import { BaseLogger } from "pino";
 import { CollateralError } from "../errors";
 
 import { getRebalanceProfile } from "./config";
-import { Zero } from "@ethersproject/constants";
 
 /**
  * This function should be called before a transfer is created/forwarded.

--- a/modules/server-node/src/index.ts
+++ b/modules/server-node/src/index.ts
@@ -612,7 +612,7 @@ server.post<{ Body: NodeParams.SendDepositTx }>(
       }
       return reply.status(500).send(jsonifyError(depositRes.getError()!));
     }
-    return reply.status(200).send({ txHash: depositRes.getValue().hash });
+    return reply.status(200).send({ txHash: depositRes.getValue().transactionHash });
   },
 );
 
@@ -1073,10 +1073,10 @@ server.post<{ Body: NodeParams.RetryWithdrawTransaction }>(
       if (tx.isError) {
         return reply.status(500).send(jsonifyError(tx.getError()!));
       }
-      commitment!.addTransaction(tx.getValue().hash);
+      commitment!.addTransaction(tx.getValue().transactionHash);
       await store.saveWithdrawalCommitment(request.body.transferId, commitment!.toJson());
       return reply.status(200).send({
-        transactionHash: tx.getValue().hash,
+        transactionHash: tx.getValue().transactionHash,
         transferId: request.body.transferId,
         channelAddress: channel.channelAddress,
       });
@@ -1391,7 +1391,7 @@ server.post<{ Body: NodeParams.SpeedUpTx }>("/speed-up", async (request, reply) 
   if (result.isError) {
     return reply.status(500).send(jsonifyError(result.getError()!));
   }
-  return reply.status(200).send({ transactionHash: result.getValue().hash });
+  return reply.status(200).send({ transactionHash: result.getValue().transactionHash });
 });
 
 server.post<{ Body: NodeParams.SendExitChannelTx }>("/sync-disputes", async (request, reply) => {

--- a/modules/server-node/src/services/store.ts
+++ b/modules/server-node/src/services/store.ts
@@ -301,40 +301,43 @@ export class PrismaStore implements IServerNodeStore {
     const activeTransactions = await this.prisma.onchainTransaction.findMany({
       where: {
         transactionHash: {
-          not: undefined
+          not: undefined,
         },
         // TODO: Any other key fields that we know HAVE to be defined for receipts that we should include here?
         // If these key receipt fields are undefined, then we know we never got
         // a valid receipt for this transaction.
         blockHash: undefined,
         gasUsed: undefined,
-      }
+      },
     });
-    return activeTransactions.map(t => ({
-      channelAddress: t.channelAddress,
-      status: t.status,
-      reason: t.reason,
-      error: t.error ?? undefined,
-      to: t.to,
-      from: t.from,
-      data: t.data,
-      value: t.value,
-      nonce: t.nonce,
-      gasLimit: t.gasLimit,
-      transactionHash: t.transactionHash,
-      timestamp: t.timestamp ?? undefined,
-      raw: t.raw ?? undefined,
-      blockHash: t.blockHash ?? undefined,
-      blockNumber: t.blockNumber ?? undefined,
-      logs: t.logs ?? undefined,
-      contractAddress: t.contractAddress ?? undefined,
-      transactionIndex: t.transactionIndex ?? undefined,
-      root: t.root ?? undefined,
-      gasUsed: t.gasUsed ?? undefined,
-      logsBloom: t.logsBloom ?? undefined,
-      cumulativeGasUsed: t.cumulativeGasUsed ?? undefined,
-      byzantium: t.byzantium ?? undefined,
-    } as StoredTransaction))
+    return activeTransactions.map(
+      (t) =>
+        ({
+          channelAddress: t.channelAddress,
+          status: t.status,
+          reason: t.reason,
+          error: t.error ?? undefined,
+          to: t.to,
+          from: t.from,
+          data: t.data,
+          value: t.value,
+          nonce: t.nonce,
+          gasLimit: t.gasLimit,
+          transactionHash: t.transactionHash,
+          timestamp: t.timestamp ?? undefined,
+          raw: t.raw ?? undefined,
+          blockHash: t.blockHash ?? undefined,
+          blockNumber: t.blockNumber ?? undefined,
+          logs: t.logs ?? undefined,
+          contractAddress: t.contractAddress ?? undefined,
+          transactionIndex: t.transactionIndex ?? undefined,
+          root: t.root ?? undefined,
+          gasUsed: t.gasUsed ?? undefined,
+          logsBloom: t.logsBloom ?? undefined,
+          cumulativeGasUsed: t.cumulativeGasUsed ?? undefined,
+          byzantium: t.byzantium ?? undefined,
+        } as StoredTransaction),
+    );
   }
 
   async getTransactionByHash(transactionHash: string): Promise<StoredTransaction | undefined> {
@@ -411,9 +414,9 @@ export class PrismaStore implements IServerNodeStore {
         to: transaction.to,
         from: transaction.from,
         blockHash: transaction.blockHash,
-        blockNumber: transaction.blockNumber,
+        blockNumber: BigNumber.from(transaction.blockNumber).toNumber(),
         contractAddress: transaction.contractAddress,
-        transactionIndex: transaction.transactionIndex,
+        transactionIndex: BigNumber.from(transaction.transactionIndex).toNumber(),
         root: transaction.root,
         gasUsed: transaction.gasUsed.toString(),
         logsBloom: transaction.logsBloom,

--- a/modules/server-node/src/services/withdrawal.spec.ts
+++ b/modules/server-node/src/services/withdrawal.spec.ts
@@ -75,7 +75,7 @@ describe(testName, () => {
     store = Sinon.createStubInstance(PrismaStore);
 
     // default all mocks to be ok
-    chainService.sendWithdrawTx.resolves(Result.ok({ hash: transactionHash }) as any);
+    chainService.sendWithdrawTx.resolves(Result.ok({ transactionHash }) as any);
     chainService.getRegisteredTransferByName.resolves(Result.ok({ definition: transferDefinition }) as any);
     chainService.getWithdrawalTransactionRecord.resolves(Result.ok(false));
     store.saveWithdrawalCommitment.resolves();

--- a/modules/server-node/src/services/withdrawal.ts
+++ b/modules/server-node/src/services/withdrawal.ts
@@ -185,10 +185,10 @@ export const submitWithdrawalToChain = async (
 
   // submission was successful, update commitment with hash
   logger.info(
-    { transactionHash: response.getValue().hash, channelAddress: channel.channelAddress },
+    { transactionHash: response.getValue().transactionHash, channelAddress: channel.channelAddress },
     "Submitted withdrawal to chain",
   );
-  commitment.addTransaction(response.getValue().hash);
+  commitment.addTransaction(response.getValue().transactionHash);
   try {
     await store.saveWithdrawalCommitment(transfer.transferId, commitment.toJson());
   } catch (e) {
@@ -205,7 +205,7 @@ export const submitWithdrawalToChain = async (
 
   logger.debug({ method, methodId }, "Method complete");
   return Result.ok({
-    transactionHash: response.getValue().hash,
+    transactionHash: response.getValue().transactionHash,
     transferId: transfer.transferId,
     channelAddress: channel.channelAddress,
   });

--- a/modules/test-runner/src/trio/happy.test.ts
+++ b/modules/test-runner/src/trio/happy.test.ts
@@ -120,7 +120,7 @@ describe(testName, () => {
     expect(cancelled.length).to.be.eq(0);
   });
 
-  it("ETH: should be able to dispute a channel", async () => {
+  it.only("ETH: should be able to dispute a channel", async () => {
     const assetId = constants.AddressZero;
     const depositAmt = utils.parseEther("0.1");
     const carolRogerPostSetup = await setup(carolService, rogerService, chainId1);
@@ -139,7 +139,7 @@ describe(testName, () => {
 
     await advanceBlocktime(parseInt(carolRogerPostSetup.timeout) + 5_000);
 
-    await defundChannel(rogerService, carolRogerPostDeposit.channelAddress, provider1);
+    await defundChannel(rogerService, carolRogerPostDeposit.channelAddress);
 
     // exit carol (only one with balance)
     await exitAssets(

--- a/modules/test-runner/src/trio/happy.test.ts
+++ b/modules/test-runner/src/trio/happy.test.ts
@@ -120,7 +120,7 @@ describe(testName, () => {
     expect(cancelled.length).to.be.eq(0);
   });
 
-  it.only("ETH: should be able to dispute a channel", async () => {
+  it("ETH: should be able to dispute a channel", async () => {
     const assetId = constants.AddressZero;
     const depositAmt = utils.parseEther("0.1");
     const carolRogerPostSetup = await setup(carolService, rogerService, chainId1);

--- a/modules/test-runner/src/utils/channel.ts
+++ b/modules/test-runner/src/utils/channel.ts
@@ -413,13 +413,10 @@ export const disputeChannel = async (
 
   const disputeRes = await disputer.sendDisputeChannelTx({ channelAddress });
   expect(disputeRes.isError).to.be.false;
-  const [transaction] = await Promise.all([
-    waitForTransaction(provider, disputeRes.getValue().transactionHash),
-    delay(8_000),
-  ]);
 
   // Verify stored disputes
-  const block = await provider.getBlock(transaction.getValue().blockNumber);
+  const tx = await provider.getTransactionReceipt(disputeRes.getValue().transactionHash);
+  const block = await provider.getBlock(tx.blockNumber);
   const [disputerRecord, counterpartyRecord] = await Promise.all([
     disputer.getChannelDispute({ channelAddress }),
     counterparty.getChannelDispute({ channelAddress }),
@@ -447,24 +444,15 @@ export const disputeChannel = async (
   // expect(counterpartyChannel.getValue()?.inDispute).to.be.true;
 };
 
-export const defundChannel = async (
-  defunder: INodeService,
-  channelAddress: string,
-  provider: providers.JsonRpcProvider,
-) => {
+export const defundChannel = async (defunder: INodeService, channelAddress: string) => {
   const defundRes = await defunder.sendDefundChannelTx({ channelAddress });
   expect(defundRes.isError).to.be.false;
-  const [transaction] = await Promise.all([
-    waitForTransaction(provider, defundRes.getValue().transactionHash),
-    delay(5_000),
-  ]);
 
   // Verify event payload
   const channel = (await defunder.getStateChannel({ channelAddress })).getValue()!;
   expect(channel).to.be.ok;
   const dispute = await defunder.getChannelDispute({ channelAddress });
   expect(dispute.getValue()).to.be.ok;
-  expect(transaction.isError).to.be.false;
 };
 
 export const exitAssets = async (
@@ -500,10 +488,6 @@ export const exitAssets = async (
     expect(result.transactionHash).to.be.ok;
     expect(result.assetId).to.be.eq(assetIds[idx]);
     expect(result.error).to.be.undefined;
-  });
-  const txs = await Promise.all(results.map((r) => waitForTransaction(provider, r.transactionHash!)));
-  txs.map((tx) => {
-    expect(tx.isError).to.be.false;
   });
 
   const recipientPostExit = await Promise.all(

--- a/modules/types/src/chain.ts
+++ b/modules/types/src/chain.ts
@@ -76,6 +76,7 @@ export class ChainError extends VectorError {
     UnderpricedReplacement: "replacement transaction underpriced",
     AncientBlockSync: "Block information is incomplete while ancient",
     UnableToRent: "Unable to rent an instance of IEthModule",
+    ConfirmationTimeout: "Timed out waiting for confirmation.",
   };
 
   readonly canRetry: boolean;

--- a/modules/types/src/chain.ts
+++ b/modules/types/src/chain.ts
@@ -255,37 +255,37 @@ export interface IVectorChainService extends IVectorChainReader {
     sender: string,
     amount: string,
     assetId: string,
-  ): Promise<Result<TransactionResponseWithResult, ChainError>>;
+  ): Promise<Result<TransactionReceipt, ChainError>>;
   sendWithdrawTx(
     channelState: FullChannelState,
     minTx: MinimalTransaction,
-  ): Promise<Result<TransactionResponseWithResult, ChainError>>;
+  ): Promise<Result<TransactionReceipt, ChainError>>;
   sendDeployChannelTx(
     channelState: FullChannelState,
     deposit?: { amount: string; assetId: string }, // Included IFF createChannelAndDepositAlice
-  ): Promise<Result<TransactionResponseWithResult, ChainError>>;
+  ): Promise<Result<TransactionReceipt, ChainError>>;
 
   // Dispute methods
-  sendDisputeChannelTx(channelState: FullChannelState): Promise<Result<TransactionResponseWithResult, ChainError>>;
-  sendDefundChannelTx(channelState: FullChannelState): Promise<Result<TransactionResponseWithResult, ChainError>>;
+  sendDisputeChannelTx(channelState: FullChannelState): Promise<Result<TransactionReceipt, ChainError>>;
+  sendDefundChannelTx(channelState: FullChannelState): Promise<Result<TransactionReceipt, ChainError>>;
   sendDisputeTransferTx(
     transferIdToDispute: string,
     activeTransfers: FullTransferState[],
-  ): Promise<Result<TransactionResponseWithResult, ChainError>>;
-  sendDefundTransferTx(transferState: FullTransferState): Promise<Result<TransactionResponseWithResult, ChainError>>;
+  ): Promise<Result<TransactionReceipt, ChainError>>;
+  sendDefundTransferTx(transferState: FullTransferState): Promise<Result<TransactionReceipt, ChainError>>;
   sendExitChannelTx(
     channelAddress: string,
     chainId: number,
     assetId: string,
     owner: string,
     recipient: string,
-  ): Promise<Result<TransactionResponseWithResult, ChainError>>;
+  ): Promise<Result<TransactionReceipt, ChainError>>;
 
   // Resend tx at the same nonce
   speedUpTx(
     chainId: number,
     tx: MinimalTransaction & { transactionHash: string; nonce: number },
-  ): Promise<Result<TransactionResponseWithResult, ChainError>>;
+  ): Promise<Result<TransactionReceipt, ChainError>>;
 
   // Event methods
   on<T extends ChainServiceEvent>(

--- a/modules/types/src/chain.ts
+++ b/modules/types/src/chain.ts
@@ -65,6 +65,7 @@ export class ChainError extends VectorError {
     TxAlreadyMined: "Tranasction already mined",
     TxNotFound: "Transaction not found",
     TxReverted: "Transaction reverted on chain",
+    MaxGasPriceReached: "Max gas price reached",
   };
 
   // Errors you would see from trying to send a transaction, and

--- a/modules/types/src/store.ts
+++ b/modules/types/src/store.ts
@@ -132,6 +132,7 @@ export interface IChainServiceStore {
 
   // Getters
   getTransactionByHash(transactionHash: string): Promise<StoredTransaction | undefined>;
+  getActiveTransactions(): Promise<StoredTransaction[]>;
 
   // Setters
   saveTransactionResponse(

--- a/modules/utils/src/test/services/store.ts
+++ b/modules/utils/src/test/services/store.ts
@@ -15,9 +15,14 @@ import {
 import { TransactionReceipt, TransactionResponse } from "@ethersproject/abstract-provider";
 
 export class MemoryStoreService implements IEngineStore {
+  getActiveTransactions(): Promise<[StoredTransaction]> {
+    throw new Error("Method not implemented.");
+  }
+
   getWithdrawalCommitmentByTransactionHash(transactionHash: string): Promise<WithdrawCommitmentJson> {
     throw new Error("Method not implemented.");
   }
+
   saveChannelDispute(
     channelAddress: string,
     channelDispute: ChannelDispute,

--- a/modules/utils/src/test/services/store.ts
+++ b/modules/utils/src/test/services/store.ts
@@ -15,7 +15,7 @@ import {
 import { TransactionReceipt, TransactionResponse } from "@ethersproject/abstract-provider";
 
 export class MemoryStoreService implements IEngineStore {
-  getActiveTransactions(): Promise<[StoredTransaction]> {
+  getActiveTransactions(): Promise<StoredTransaction[]> {
     throw new Error("Method not implemented.");
   }
 


### PR DESCRIPTION
## The Problem
Copied from: https://www.notion.so/connext/Withdrawal-Retry-Fixes-d355810cb2944818ae63b601bac04f85

Withdrawals in some cases will not be fully submitted. These are some of the failure cases we have recently experienced:

- Withdrawal commitment never submitted onchain. Could be from ill-timed router restart, or provider failure.
- Withdrawal commitment submitted onchain, tx hash is available, but tx receipt is not available. This is effectively a "bad tx" that needs to be retried with the same parameters.
- Withdrawal commitment is submitted on chain, but we have no record of its receipt. Can be caused by ill-timed router restart while waiting for the receipt.

## The Solution
From: https://www.notion.so/connext/Withdrawal-Retry-Fixes-d355810cb2944818ae63b601bac04f85

- [x]  Submit tx to chain. Catch retryable errors and retry if failure. Ex: Nonce too low means there's a race with other txs sending, so keep retrying until it works. Record the following in DB: `nonce`, `to`, `value`, `data`, `hash`, `gasPrice`, `gasLimit`. Emit `TRANSACTION_SUBMITTED` event.
- [ ]  Poll every 2 seconds until `getTransactionReceipt` returns a valid receipt. After 15 seconds, speed up the tx by sending at the same nonce with higher gas price. Amount to bump price can be configurable.
    - Note: Do not trust Ethers listeners for this process since the `tx.wait()` might resolve but no tx receipt will be available, especially for non-ETH chains.
- [x]  Save tx receipt to DB. If `receipt.status === 0`, tx is reverted, Emit `TRANSACTION_REVERTED` event, else emit `TRANSACTION_MINED` event.
- [ ]  On node startup:
    - Pull transactions that have a tx hash but no receipt.
    - Check if txs have been mined. If so, save receipt to DB. If `receipt.status === 0`, tx is reverted, Emit `TRANSACTION_REVERTED` event, else emit `TRANSACTION_MINED` event.
    - If not, resubmit at same nonce and higher gas price. (TODO: How to handle nonce errors here? Does it really matter if we get them?).
