### PR TITLE
Use static provider

### DIFF
--- a/modules/utils/src/eth.ts
+++ b/modules/utils/src/eth.ts
@@ -1,7 +1,7 @@
 import { ChainProviders, HydratedProviders } from "@connext/vector-types";
 import { Provider } from "@ethersproject/abstract-provider";
 import { BigNumber } from "@ethersproject/bignumber";
-import { JsonRpcProvider } from "@ethersproject/providers";
+import { JsonRpcProvider, StaticJsonRpcProvider } from "@ethersproject/providers";
 
 const classicProviders = ["https://www.ethercluster.com/etc"];
 const classicChainIds = [61];
@@ -23,7 +23,7 @@ export const getGasPrice = async (provider: Provider, providedChainId?: number):
 export const hydrateProviders = (chainProviders: ChainProviders): HydratedProviders => {
   const hydratedProviders: { [url: string]: JsonRpcProvider } = {};
   Object.entries(chainProviders).map(([chainId, url]) => {
-    hydratedProviders[chainId] = new JsonRpcProvider(url as string, parseInt(chainId));
+    hydratedProviders[chainId] = new StaticJsonRpcProvider(url as string, parseInt(chainId));
   });
   return hydratedProviders;
 };


### PR DESCRIPTION
## The Problem
<!--- Why is this change required? What problem does it solve? Bug fix or new feature? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Too many chainId calls. Fixes #584 

## The Solution
<!--- Describe the changes you made at a high level -->
<!--- Leave comments on the source diff to draw attention to important low-level specifics -->
Reduce chainId calls by using StaticJsonProvider.

https://github.com/ethers-io/ethers.js/issues/901