### PR TITLE
Fix merkle tree WASM module to be included in router image

### DIFF
--- a/modules/router/ops/webpack.config.js
+++ b/modules/router/ops/webpack.config.js
@@ -63,6 +63,10 @@ module.exports = {
           to: path.join(__dirname, "../dist/pure-evm_bg.wasm"),
         },
         {
+          from: path.join(__dirname, "../../../node_modules/@connext/vector-merkle-tree/dist/node/index_bg.wasm"),
+          to: path.join(__dirname, "../dist/index_bg.wasm"),
+        },
+        {
           from: path.join(__dirname, "../prisma-postgres"),
           to: path.join(__dirname, "../dist/prisma-postgres"),
         },

--- a/modules/router/ops/webpack.config.js
+++ b/modules/router/ops/webpack.config.js
@@ -52,6 +52,11 @@ module.exports = {
           },
         },
       },
+      {
+        test: /\.wasm$/,
+        type: "javascript/auto",
+        use: "wasm-loader",
+      },
     ],
   },
 

--- a/modules/router/package.json
+++ b/modules/router/package.json
@@ -14,6 +14,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@connext/vector-merkle-tree": "0.1.2",
     "@connext/vector-contracts": "0.2.5-alpha.2",
     "@connext/vector-engine": "0.2.5-alpha.2",
     "@connext/vector-types": "0.2.5-alpha.2",


### PR DESCRIPTION
This should make the `routing-node-prod` and `messaging-prod` CI targets work. We'll see.