### PR TITLE
Tx service robust

### DIFF
--- a/modules/contracts/src.ts/services/ethService.spec.ts
+++ b/modules/contracts/src.ts/services/ethService.spec.ts
@@ -420,7 +420,7 @@ describe.only("ethService unit test", () => {
     });
 
     it("errors if transaction is confirmed", async () => {
-      provider1337.getTransaction.resolves({ confirmations: 1 } as any);
+      stub(ethService, "getTxResponseFromHash").resolves(Result.ok({ response: txResponse, receipt: txReceipt }));
       const result = await ethService.speedUpTx(1337, minTx);
       assertResult(result, true, ChainError.reasons.TxAlreadyMined);
     });

--- a/modules/contracts/src.ts/services/ethService.spec.ts
+++ b/modules/contracts/src.ts/services/ethService.spec.ts
@@ -490,7 +490,7 @@ describe.only("ethService unit test", () => {
     });
   });
 
-  describe.only("sendAndConfirmTx", () => {
+  describe("sendAndConfirmTx", () => {
     beforeEach(() => {
       waitForConfirmation = stub(ethService, "waitForConfirmation");
     });
@@ -573,8 +573,9 @@ describe.only("ethService unit test", () => {
       assertResult(result, true, "Booooo");
     });
 
-    it("happy: saves responses", async () => {
-      const result = await ethService.sendAndConfirmTx(AddressZero, 111, "allowance", async () => {
+    it("happy: saves responses if confirmation happens on first loop", async () => {
+      waitForConfirmation.resolves(txReceipt);
+      const result = await ethService.sendAndConfirmTx(AddressZero, 1337, "allowance", async () => {
         return _txResponse;
       });
       expect(storeMock.saveTransactionResponse.callCount).eq(1);

--- a/modules/contracts/src.ts/services/ethService.spec.ts
+++ b/modules/contracts/src.ts/services/ethService.spec.ts
@@ -55,7 +55,7 @@ const assertResult = (result: Result<any>, isError: boolean, unwrappedVal?: any)
   }
 };
 
-const _txResponse = {
+const txResponse = {
   chainId: 1337,
   confirmations: 1,
   data: "0x",
@@ -75,12 +75,12 @@ const txReceipt: TransactionReceipt = {
   confirmations: 1,
   contractAddress: mkAddress("0xa"),
   cumulativeGasUsed: BigNumber.from(21000),
-  from: _txResponse.from,
+  from: txResponse.from,
   gasUsed: BigNumber.from(21000),
   logs: [],
   logsBloom: "0x",
   to: mkAddress("0xbbb"),
-  transactionHash: _txResponse.hash,
+  transactionHash: txResponse.hash,
   transactionIndex: 1,
   status: 1,
 };
@@ -96,7 +96,7 @@ describe.only("ethService unit test", () => {
     (signer as any)._isSigner = true;
 
     const _provider = createStubInstance(JsonRpcProvider);
-    _provider.getTransaction.resolves(_txResponse);
+    _provider.getTransaction.resolves(txResponse);
     provider1337 = _provider;
     provider1338 = _provider;
     (signer as any).provider = provider1337;
@@ -450,7 +450,7 @@ describe.only("ethService unit test", () => {
         channelState.networkContext.chainId,
         "allowance",
         () => {
-          return Promise.resolve(_txResponse);
+          return Promise.resolve(txResponse);
         },
       );
       assertResult(result, true, ChainError.reasons.NotEnoughFunds);
@@ -473,7 +473,7 @@ describe.only("ethService unit test", () => {
         channelState.networkContext.chainId,
         "allowance",
         () => {
-          return Promise.resolve(_txResponse);
+          return Promise.resolve(txResponse);
         },
       );
       assertResult(result, false, txReceipt);
@@ -485,7 +485,7 @@ describe.only("ethService unit test", () => {
         channelState.networkContext.chainId,
         "allowance",
         () => {
-          return Promise.resolve(_txResponse);
+          return Promise.resolve(txResponse);
         },
       );
       assertResult(result, false, txReceipt);
@@ -540,18 +540,18 @@ describe.only("ethService unit test", () => {
     it("if receipt status == 0, saves response with error", async () => {
       waitForConfirmation.resolves({ ...txReceipt, status: 0 });
       const result = await ethService.sendAndConfirmTx(AddressZero, 1337, "allowance", async () => {
-        return _txResponse;
+        return txResponse;
       });
       expect(storeMock.saveTransactionResponse.callCount).eq(1);
       const saveTransactionResponseCall = storeMock.saveTransactionResponse.getCall(0);
       expect(saveTransactionResponseCall.args[0]).eq(AddressZero);
       expect(saveTransactionResponseCall.args[1]).eq("allowance");
-      expect(saveTransactionResponseCall.args[2]).deep.eq(_txResponse);
+      expect(saveTransactionResponseCall.args[2]).deep.eq(txResponse);
 
       expect(storeMock.saveTransactionFailure.callCount).eq(1);
       const saveTransactionFailureCall = storeMock.saveTransactionFailure.getCall(0);
       expect(saveTransactionFailureCall.args[0]).eq(AddressZero);
-      expect(saveTransactionFailureCall.args[1]).eq(_txResponse.hash);
+      expect(saveTransactionFailureCall.args[1]).eq(txResponse.hash);
       expect(saveTransactionFailureCall.args[2]).eq("Tx reverted");
       assertResult(result, true, ChainError.reasons.TxReverted);
     });
@@ -560,38 +560,38 @@ describe.only("ethService unit test", () => {
       const error = new Error("Booooo");
       waitForConfirmation.rejects(error);
       const result = await ethService.sendAndConfirmTx(AddressZero, 1337, "allowance", async () => {
-        return _txResponse;
+        return txResponse;
       });
       expect(storeMock.saveTransactionResponse.callCount).eq(1);
       const saveTransactionResponseCall = storeMock.saveTransactionResponse.getCall(0);
       expect(saveTransactionResponseCall.args[0]).eq(AddressZero);
       expect(saveTransactionResponseCall.args[1]).eq("allowance");
-      expect(saveTransactionResponseCall.args[2]).deep.eq(_txResponse);
+      expect(saveTransactionResponseCall.args[2]).deep.eq(txResponse);
 
       expect(storeMock.saveTransactionFailure.callCount).eq(1);
       const saveTransactionFailureCall = storeMock.saveTransactionFailure.getCall(0);
       expect(saveTransactionFailureCall.args[0]).eq(AddressZero);
-      expect(saveTransactionFailureCall.args[1]).eq(_txResponse.hash);
+      expect(saveTransactionFailureCall.args[1]).eq(txResponse.hash);
       expect(saveTransactionFailureCall.args[2]).eq("Booooo");
       assertResult(result, true, "Booooo");
     });
 
     it("retries transaction with higher gas price", async () => {
-      const newTx = { ..._txResponse, hash: mkHash("0xddd") }; // change hash to simulate higher gas and new hash
+      const newTx = { ...txResponse, hash: mkHash("0xddd") }; // change hash to simulate higher gas and new hash
       const newReceipt = { ...txReceipt, transactionHash: newTx.hash };
       waitForConfirmation.onFirstCall().rejects(new ChainError(ChainError.retryableTxErrors.ConfirmationTimeout));
       signer.sendTransaction.resolves(newTx); // new tx with higher gas
       waitForConfirmation.onSecondCall().resolves(newReceipt);
 
       const result = await ethService.sendAndConfirmTx(AddressZero, 1337, "allowance", async () => {
-        return _txResponse;
+        return txResponse;
       });
 
       expect(storeMock.saveTransactionResponse.callCount).eq(2);
       const saveTransactionResponseCall = storeMock.saveTransactionResponse.getCall(0);
       expect(saveTransactionResponseCall.args[0]).eq(AddressZero);
       expect(saveTransactionResponseCall.args[1]).eq("allowance");
-      expect(saveTransactionResponseCall.args[2]).deep.eq(_txResponse);
+      expect(saveTransactionResponseCall.args[2]).deep.eq(txResponse);
 
       const saveTransactionResponseCall2 = storeMock.saveTransactionResponse.getCall(1);
       expect(saveTransactionResponseCall2.args[0]).eq(AddressZero);
@@ -610,19 +610,19 @@ describe.only("ethService unit test", () => {
       waitForConfirmation.onFirstCall().rejects(new ChainError(ChainError.retryableTxErrors.ConfirmationTimeout));
 
       const result = await ethService.sendAndConfirmTx(AddressZero, 1337, "allowance", async () => {
-        return _txResponse;
+        return txResponse;
       });
 
       expect(storeMock.saveTransactionResponse.callCount).eq(1);
       const saveTransactionResponseCall = storeMock.saveTransactionResponse.getCall(0);
       expect(saveTransactionResponseCall.args[0]).eq(AddressZero);
       expect(saveTransactionResponseCall.args[1]).eq("allowance");
-      expect(saveTransactionResponseCall.args[2]).deep.eq(_txResponse);
+      expect(saveTransactionResponseCall.args[2]).deep.eq(txResponse);
 
       expect(storeMock.saveTransactionFailure.callCount).eq(1);
       const saveTransactionFailureCall = storeMock.saveTransactionFailure.getCall(0);
       expect(saveTransactionFailureCall.args[0]).eq(AddressZero);
-      expect(saveTransactionFailureCall.args[1]).eq(_txResponse.hash);
+      expect(saveTransactionFailureCall.args[1]).eq(txResponse.hash);
       expect(saveTransactionFailureCall.args[2]).eq(ChainError.reasons.MaxGasPriceReached);
 
       assertResult(result, true, ChainError.reasons.MaxGasPriceReached);
@@ -631,19 +631,43 @@ describe.only("ethService unit test", () => {
     it("happy: saves responses if confirmation happens on first loop", async () => {
       waitForConfirmation.resolves(txReceipt);
       const result = await ethService.sendAndConfirmTx(AddressZero, 1337, "allowance", async () => {
-        return _txResponse;
+        return txResponse;
       });
       expect(storeMock.saveTransactionResponse.callCount).eq(1);
       const saveTransactionResponseCall = storeMock.saveTransactionResponse.getCall(0);
       expect(saveTransactionResponseCall.args[0]).eq(AddressZero);
       expect(saveTransactionResponseCall.args[1]).eq("allowance");
-      expect(saveTransactionResponseCall.args[2]).deep.eq(_txResponse);
+      expect(saveTransactionResponseCall.args[2]).deep.eq(txResponse);
 
       expect(storeMock.saveTransactionReceipt.callCount).eq(1);
       const saveTransactionReceiptCall = storeMock.saveTransactionReceipt.getCall(0);
       expect(saveTransactionReceiptCall.args[0]).eq(AddressZero);
 
-      assertResult(result, false);
+      assertResult(result, false, txReceipt);
+    });
+  });
+
+  describe("waitForConfirmation", () => {
+    it("should return an error if there is no provider for chain", async () => {
+      await expect(ethService.waitForConfirmation(111, txResponse)).to.eventually.be.rejectedWith(
+        ChainError.reasons.ProviderNotFound,
+      );
+    });
+
+    it("should wait for the required amount of confirmations", async () => {
+      provider1337.send.onFirstCall().resolves({ ...txReceipt, confirmations: 0 });
+      provider1337.send.onSecondCall().resolves({ ...txReceipt, confirmations: 0 });
+      provider1337.send.onThirdCall().resolves(txReceipt);
+      const res = await ethService.waitForConfirmation(1337, txResponse);
+      expect(res).to.deep.eq(txReceipt);
+      expect(provider1337.send.callCount).to.eq(3);
+    });
+
+    it("should error with a timeout error if it is past the confirmation time", async () => {
+      provider1337.send.onThirdCall().resolves(undefined);
+      await expect(ethService.waitForConfirmation(1337, txResponse)).to.eventually.be.rejectedWith(
+        ChainError.retryableTxErrors.ConfirmationTimeout,
+      );
     });
   });
 

--- a/modules/contracts/src.ts/services/ethService.spec.ts
+++ b/modules/contracts/src.ts/services/ethService.spec.ts
@@ -87,7 +87,7 @@ const txReceipt: TransactionReceipt = {
 };
 
 const { log } = getTestLoggers("ethService");
-describe.only("ethService unit test", () => {
+describe("ethService unit test", () => {
   beforeEach(() => {
     // eth service deps
     storeMock = createStubInstance(MemoryStoreService);

--- a/modules/contracts/src.ts/services/ethService.spec.ts
+++ b/modules/contracts/src.ts/services/ethService.spec.ts
@@ -613,14 +613,12 @@ describe.only("ethService unit test", () => {
         return _txResponse;
       });
 
-      console.log("storeMock.saveTransactionResponse.callCount: ", storeMock.saveTransactionResponse.callCount);
       expect(storeMock.saveTransactionResponse.callCount).eq(1);
       const saveTransactionResponseCall = storeMock.saveTransactionResponse.getCall(0);
       expect(saveTransactionResponseCall.args[0]).eq(AddressZero);
       expect(saveTransactionResponseCall.args[1]).eq("allowance");
       expect(saveTransactionResponseCall.args[2]).deep.eq(_txResponse);
 
-      console.log("storeMock.saveTransactionFailure.callCount: ", storeMock.saveTransactionFailure.callCount);
       expect(storeMock.saveTransactionFailure.callCount).eq(1);
       const saveTransactionFailureCall = storeMock.saveTransactionFailure.getCall(0);
       expect(saveTransactionFailureCall.args[0]).eq(AddressZero);

--- a/modules/contracts/src.ts/services/ethService.ts
+++ b/modules/contracts/src.ts/services/ethService.ts
@@ -428,7 +428,6 @@ export class EthereumChainService extends EthereumChainReader implements IVector
       }
 
       const receipt = await queuedResponse.completed;
-      console.log("queuedResponse.completed receipt: ", receipt);
       if (receipt.status === 0) {
         return Result.fail(new ChainError(ChainError.reasons.TxReverted, { receipt, method, methodId }));
       }

--- a/modules/contracts/src.ts/services/ethService.ts
+++ b/modules/contracts/src.ts/services/ethService.ts
@@ -100,11 +100,8 @@ export class EthereumChainService extends EthereumChainReader implements IVector
     this.revitalizeTxs();
   }
 
-  private getSigner(chainId: number): Signer {
+  private getSigner(chainId: number): Signer | undefined {
     const signer = this.signers.get(chainId);
-    if (!signer?._isSigner) {
-      throw new ChainError(ChainError.reasons.SignerNotFound);
-    }
     return signer;
   }
 

--- a/modules/contracts/src.ts/services/ethService.ts
+++ b/modules/contracts/src.ts/services/ethService.ts
@@ -356,6 +356,7 @@ export class EthereumChainService extends EthereumChainReader implements IVector
                   gasPrice = gasPrice.add(gasPrice.mul(GAS_BUMP_PERCENT));
 
                   // TODO: resend exact same tx with the same nonce, overwrite the response in the DB
+                  // make sure new gasPrice is being saved
                 } else {
                   // If we get any other error here, we classify this event as a tx failure and break out of the loop.
                   this.log.error({ method: "sendTxAndParseResponse", error: jsonifyError(e) }, "Transaction reverted.");

--- a/modules/contracts/src.ts/tests/integration/ethService.spec.ts
+++ b/modules/contracts/src.ts/tests/integration/ethService.spec.ts
@@ -23,7 +23,7 @@ import { advanceBlocktime, getContract, createChannel } from "../../utils";
 
 import { EthereumChainService } from "../../services/ethService";
 
-describe("EthereumChainService", function () {
+describe("ethService integration", function () {
   this.timeout(120_000);
   const aliceSigner = new ChannelSigner(alice.privateKey);
   const bobSigner = new ChannelSigner(bob.privateKey);

--- a/modules/types/src/chain.ts
+++ b/modules/types/src/chain.ts
@@ -255,37 +255,37 @@ export interface IVectorChainService extends IVectorChainReader {
     sender: string,
     amount: string,
     assetId: string,
-  ): Promise<Result<TransactionResponseWithResult, ChainError>>;
+  ): Promise<Result<TransactionReceipt, ChainError>>;
   sendWithdrawTx(
     channelState: FullChannelState,
     minTx: MinimalTransaction,
-  ): Promise<Result<TransactionResponseWithResult, ChainError>>;
+  ): Promise<Result<TransactionReceipt, ChainError>>;
   sendDeployChannelTx(
     channelState: FullChannelState,
     deposit?: { amount: string; assetId: string }, // Included IFF createChannelAndDepositAlice
-  ): Promise<Result<TransactionResponseWithResult, ChainError>>;
+  ): Promise<Result<TransactionReceipt, ChainError>>;
 
   // Dispute methods
-  sendDisputeChannelTx(channelState: FullChannelState): Promise<Result<TransactionResponseWithResult, ChainError>>;
-  sendDefundChannelTx(channelState: FullChannelState): Promise<Result<TransactionResponseWithResult, ChainError>>;
+  sendDisputeChannelTx(channelState: FullChannelState): Promise<Result<TransactionReceipt, ChainError>>;
+  sendDefundChannelTx(channelState: FullChannelState): Promise<Result<TransactionReceipt, ChainError>>;
   sendDisputeTransferTx(
     transferIdToDispute: string,
     activeTransfers: FullTransferState[],
-  ): Promise<Result<TransactionResponseWithResult, ChainError>>;
-  sendDefundTransferTx(transferState: FullTransferState): Promise<Result<TransactionResponseWithResult, ChainError>>;
+  ): Promise<Result<TransactionReceipt, ChainError>>;
+  sendDefundTransferTx(transferState: FullTransferState): Promise<Result<TransactionReceipt, ChainError>>;
   sendExitChannelTx(
     channelAddress: string,
     chainId: number,
     assetId: string,
     owner: string,
     recipient: string,
-  ): Promise<Result<TransactionResponseWithResult, ChainError>>;
+  ): Promise<Result<TransactionReceipt, ChainError>>;
 
   // Resend tx at the same nonce
   speedUpTx(
     chainId: number,
     tx: MinimalTransaction & { transactionHash: string; nonce: number },
-  ): Promise<Result<TransactionResponseWithResult, ChainError>>;
+  ): Promise<Result<TransactionReceipt, ChainError>>;
 
   // Event methods
   on<T extends ChainServiceEvent>(

--- a/modules/types/src/chain.ts
+++ b/modules/types/src/chain.ts
@@ -65,6 +65,7 @@ export class ChainError extends VectorError {
     TxAlreadyMined: "Tranasction already mined",
     TxNotFound: "Transaction not found",
     TxReverted: "Transaction reverted on chain",
+    MaxGasPriceReached: "Max gas price reached",
   };
 
   // Errors you would see from trying to send a transaction, and


### PR DESCRIPTION
~A couple issues I saw:
~- The `sendTxAndParseResponse` function should return the response immediately after it's sent (to chain).~
~- The `completed` function should be what handles all the monitoring and gas price bumping.~

Edit: Rethought of the above. All the submitted vs mined discrepancy needs to be handled in this tx service. All the callers should only care about the receipt when it's mined.

- [x] Tx isn't being resent at a higher gas price?
