### PR TITLE
Submit unsubmitted withdrawals on isAlive

### DIFF
--- a/modules/browser-node/src/services/store.ts
+++ b/modules/browser-node/src/services/store.ts
@@ -103,6 +103,10 @@ class VectorIndexedDBDatabase extends Dexie {
     });
 
     this.version(4).stores({
+      withdrawCommitment: "transferId,channelAddress",
+    });
+
+    this.version(4).stores({
       channelDisputes: "channelAddress",
       transferDisputes: "transferId",
     });
@@ -310,9 +314,11 @@ export class BrowserStore implements IEngineStore, IChainServiceStore {
   }
 
   async getActiveTransactions(): Promise<StoredTransaction[]> {
-    const tx = await this.db.transactions.filter(tx => {
-      return !!tx.transactionHash && !tx.blockHash && !tx.gasUsed
-    }).toArray();
+    const tx = await this.db.transactions
+      .filter((tx) => {
+        return !!tx.transactionHash && !tx.blockHash && !tx.gasUsed;
+      })
+      .toArray();
     return tx;
   }
 
@@ -395,6 +401,21 @@ export class BrowserStore implements IEngineStore, IChainServiceStore {
     }
     const { transferId, ...commitment } = w;
     return commitment;
+  }
+
+  // TOOD: dont really need this yet, but prob will soon
+  getUnsubmittedWithdrawals(
+    channelAddress: string,
+    withdrawalDefinition: string,
+  ): Promise<
+    {
+      commitment: WithdrawCommitmentJson; // function. However, the constructor should *not* be used when creating
+      // function. However, the constructor should *not* be used when creating
+      // an instance of the BrowserStore
+      transfer: FullTransferState<any>;
+    }[]
+  > {
+    throw new Error("Method not implemented.");
   }
 
   async saveTransferDispute(

--- a/modules/browser-node/src/services/store.ts
+++ b/modules/browser-node/src/services/store.ts
@@ -103,12 +103,12 @@ class VectorIndexedDBDatabase extends Dexie {
     });
 
     this.version(4).stores({
-      withdrawCommitment: "transferId,channelAddress",
-    });
-
-    this.version(4).stores({
       channelDisputes: "channelAddress",
       transferDisputes: "transferId",
+    });
+
+    this.version(5).stores({
+      withdrawCommitment: "transferId,channelAddress,transactionHash",
     });
 
     this.channels = this.table("channels");

--- a/modules/engine/src/listeners.ts
+++ b/modules/engine/src/listeners.ts
@@ -41,7 +41,7 @@ import {
 import { getRandomBytes32, hashWithdrawalQuote, mkSig } from "@connext/vector-utils";
 import { getAddress } from "@ethersproject/address";
 import { BigNumber } from "@ethersproject/bignumber";
-import { Zero } from "@ethersproject/constants";
+import { AddressZero, HashZero, Zero } from "@ethersproject/constants";
 import Pino, { BaseLogger } from "pino";
 
 import { IsAliveError, RestoreError, WithdrawQuoteError } from "./errors";
@@ -343,7 +343,8 @@ export async function setupEngineListeners(
         gasSubsidyPercentage,
       );
 
-      if (channel.networkContext.chainId !== 1) {
+      // if channel is not a mainnet channel and user is alice, we can attempt to resubmit unsubmitted withdrawals
+      if (channel.networkContext.chainId !== 1 && signer.publicIdentifier === channel.aliceIdentifier) {
         submitUnsubmittedWithdrawals(channel, store, chainAddresses, chainService, logger);
       }
 
@@ -573,19 +574,48 @@ export async function submitUnsubmittedWithdrawals(
     logger.info({ method, methodId, transferId: u.transfer.transferId }, "Submitting unsubmitted withdrawal");
     try {
       const commitment = await WithdrawCommitment.fromJson(u.commitment);
-      const tx = await chainService.sendWithdrawTx(channel, commitment.getSignedTransaction());
-      if (tx.isError) {
-        logger.error(
-          { method, methodId, error: tx.getError()?.toJson(), commitment: u },
-          "Error in chainService.sendWithdrawTx",
-        );
-      }
-      logger.info(
-        { method, methodId, transactionHash: tx.getValue().transactionHash },
-        "Submitted unsubmitted withdrawal",
+
+      // before submitting, check status
+      const wasSubmitted = await chainService.getWithdrawalTransactionRecord(
+        u.commitment,
+        channel.channelAddress,
+        channel.networkContext.chainId,
       );
-      commitment!.addTransaction(tx.getValue().transactionHash);
-      await store.saveWithdrawalCommitment(u.transfer.transferId, commitment!.toJson());
+      if (wasSubmitted.isError) {
+        logger.error(
+          { method, methodId, error: jsonifyError(wasSubmitted.getError()!) },
+          "Could not check submission status",
+        );
+        continue;
+      }
+      const noOp = commitment.amount === "0" && commitment.callTo === AddressZero;
+      if (wasSubmitted.getValue() || noOp) {
+        logger.info(
+          {
+            transferId: u.transfer.transferId,
+            channelAddress: channel.channelAddress,
+            commitment: u.commitment,
+            wasSubmitted: wasSubmitted.getValue(),
+            noOp,
+          },
+          "Previously submitted / no-op",
+        );
+        commitment.addTransaction(HashZero);
+      } else {
+        const tx = await chainService.sendWithdrawTx(channel, commitment.getSignedTransaction());
+        if (tx.isError) {
+          logger.error(
+            { method, methodId, error: tx.getError()?.toJson(), commitment: u },
+            "Error in chainService.sendWithdrawTx",
+          );
+        }
+        logger.info(
+          { method, methodId, transactionHash: tx.getValue().transactionHash },
+          "Submitted unsubmitted withdrawal",
+        );
+        commitment.addTransaction(tx.getValue().transactionHash);
+      }
+      await store.saveWithdrawalCommitment(u.transfer.transferId, commitment.toJson());
     } catch (e) {
       logger.error(
         { method, methodId, error: jsonifyError(e), commitment: u },

--- a/modules/engine/src/testing/listeners.spec.ts
+++ b/modules/engine/src/testing/listeners.spec.ts
@@ -59,6 +59,7 @@ import {
   handleWithdrawalTransferResolution,
   resolveExistingWithdrawals,
   setupEngineListeners,
+  submitUnsubmittedWithdrawals,
 } from "../listeners";
 import * as utils from "../utils";
 import * as listeners from "../listeners";
@@ -71,10 +72,10 @@ import { WithdrawQuoteError } from "../errors";
 const testName = "Engine listeners unit";
 const { log } = getTestLoggers(testName, env.logLevel);
 console.log("env.logLevel: ", env.logLevel);
+const chainId = parseInt(Object.keys(env.chainProviders)[0]);
 
 describe(testName, () => {
   // Get env constants
-  const chainId = parseInt(Object.keys(env.chainProviders)[0]);
   const withdrawAddress = mkAddress("0xdefff");
   const chainAddresses: ChainAddresses = {
     [chainId]: {
@@ -870,6 +871,52 @@ describe(testName, () => {
         } as ConditionalTransferRoutingCompletePayload),
       );
       await promise;
+    });
+  });
+
+  describe("submitUnsubmittedWithdrawals", () => {
+    it.only("should work", async () => {
+      const alice = getRandomChannelSigner();
+      const bob = getRandomChannelSigner();
+
+      const channel = createTestChannelState("create", { alice: alice.address, bob: bob.address });
+      channel.channel.networkContext.chainId = chainId;
+
+      const commitment = new WithdrawCommitment(
+        channel.channel.channelAddress,
+        alice.address,
+        bob.address,
+        mkAddress("0xabc"),
+        channel.transfer.assetId,
+        "1",
+        channel.channel.nonce.toString(),
+      );
+      const aliceSig = await alice.signMessage(commitment.hashToSign());
+      const bobSig = await bob.signMessage(commitment.hashToSign());
+
+      await commitment.addSignatures(aliceSig, bobSig);
+      console.log("commitment: ", commitment.toJson());
+
+      store.getUnsubmittedWithdrawals.resolves([
+        {
+          commitment: commitment.toJson(),
+          transfer: channel.transfer,
+        },
+        {
+          commitment: commitment.toJson(),
+          transfer: channel.transfer,
+        },
+      ]);
+      await submitUnsubmittedWithdrawals(
+        channel.channel,
+        store,
+        chainAddresses,
+        chainService as IVectorChainService,
+        log,
+      );
+
+      expect(chainService.sendWithdrawTx.callCount).to.eq(2);
+      expect(store.saveWithdrawalCommitment.callCount).to.eq(2);
     });
   });
 });

--- a/modules/engine/src/testing/listeners.spec.ts
+++ b/modules/engine/src/testing/listeners.spec.ts
@@ -876,6 +876,9 @@ describe(testName, () => {
 
   describe("submitUnsubmittedWithdrawals", () => {
     it("should work", async () => {
+      chainService.getWithdrawalTransactionRecord.onFirstCall().resolves(Result.ok(true));
+      chainService.getWithdrawalTransactionRecord.resolves(Result.ok(false));
+
       const alice = getRandomChannelSigner();
       const bob = getRandomChannelSigner();
 
@@ -915,7 +918,7 @@ describe(testName, () => {
         log,
       );
 
-      expect(chainService.sendWithdrawTx.callCount).to.eq(2);
+      expect(chainService.sendWithdrawTx.callCount).to.eq(1);
       expect(store.saveWithdrawalCommitment.callCount).to.eq(2);
     });
   });

--- a/modules/engine/src/testing/listeners.spec.ts
+++ b/modules/engine/src/testing/listeners.spec.ts
@@ -875,7 +875,7 @@ describe(testName, () => {
   });
 
   describe("submitUnsubmittedWithdrawals", () => {
-    it.only("should work", async () => {
+    it("should work", async () => {
       const alice = getRandomChannelSigner();
       const bob = getRandomChannelSigner();
 

--- a/modules/types/src/store.ts
+++ b/modules/types/src/store.ts
@@ -148,6 +148,10 @@ export interface IEngineStore extends IVectorStore, IChainServiceStore {
   // Getters
   getWithdrawalCommitment(transferId: string): Promise<WithdrawCommitmentJson | undefined>;
   getWithdrawalCommitmentByTransactionHash(transactionHash: string): Promise<WithdrawCommitmentJson | undefined>;
+  getUnsubmittedWithdrawals(
+    channelAddress: string,
+    withdrawalDefinition: string,
+  ): Promise<{ commitment: WithdrawCommitmentJson; transfer: FullTransferState }[]>;
 
   // NOTE: The engine does *not* care about the routingId (it is stored
   // in the meta of transfer objects), only the router module does.

--- a/modules/utils/src/test/services/store.ts
+++ b/modules/utils/src/test/services/store.ts
@@ -15,6 +15,13 @@ import {
 import { TransactionReceipt, TransactionResponse } from "@ethersproject/abstract-provider";
 
 export class MemoryStoreService implements IEngineStore {
+  getUnsubmittedWithdrawals(
+    channelAddress: string,
+    withdrawalDefinition: string,
+  ): Promise<{ commitment: WithdrawCommitmentJson; transfer: FullTransferState<any> }[]> {
+    throw new Error("Method not implemented.");
+  }
+
   getActiveTransactions(): Promise<StoredTransaction[]> {
     throw new Error("Method not implemented.");
   }


### PR DESCRIPTION
## The Problem
<!--- Why is this change required? What problem does it solve? Bug fix or new feature? -->
<!--- If it fixes an open issue, please link to the issue here. -->
If withdrawal doesn't submit, it never gets retried.

## The Solution
<!--- Describe the changes you made at a high level -->
<!--- Leave comments on the source diff to draw attention to important low-level specifics -->
Resubmit withdrawals.

Need to watch out for race conditions here.

Also need to integrate this into the new tx service @jakekidd. I think the new tx service changes will make this a lot better, we can look up the "in progress" tx and not resubmit.