### PR TITLE
Track nonce internally

### DIFF
--- a/modules/contracts/src.ts/services/ethService.ts
+++ b/modules/contracts/src.ts/services/ethService.ts
@@ -207,8 +207,11 @@ export class EthereumChainService extends EthereumChainReader implements IVector
           const actualNonce: number =
             nonce ?? this.nonces.get(chainId) ?? (await signer.getTransactionCount("pending"));
           const response: TransactionResponse | undefined = await txFn(gasPrice, actualNonce);
-          // After calling tx fn, set nonce to usedNonce + 1
-          this.nonces.set(chainId, actualNonce + 1);
+          // After calling tx fn, set nonce to usedNonce + 1 IFF the
+          // nonce wasnt pre-specified (i.e. not re-sending tx)
+          if (typeof nonce === undefined) {
+            this.nonces.set(chainId, actualNonce + 1);
+          }
           return Result.ok(response);
         } catch (e) {
           return Result.fail(e);

--- a/modules/contracts/src.ts/services/ethService.ts
+++ b/modules/contracts/src.ts/services/ethService.ts
@@ -214,14 +214,12 @@ export class EthereumChainService extends EthereumChainReader implements IVector
         // After calling tx fn, set nonce to the greatest of
         // stored, pending, or incremented
         const pending = await signer.getTransactionCount("pending");
-        const incremented = nonceToUse + 1;
+        const incremented = (response?.nonce ?? nonceToUse) + 1;
         // Ensure the nonce you store is *always* the greatest of the values
         const toCompare = stored ?? 0;
-        if (toCompare >= incremented && toCompare >= pending) {
-          // return without updating
-          return Result.ok(response);
+        if (toCompare < pending || toCompare < incremented) {
+          this.nonces.set(chainId, incremented > pending ? incremented : pending);
         }
-        this.nonces.set(chainId, incremented > pending ? incremented : pending);
         return Result.ok(response);
       } catch (e) {
         return Result.fail(e);


### PR DESCRIPTION
## The Problem
<!--- Why is this change required? What problem does it solve? Bug fix or new feature? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Sometimes seeing error where nonce is being used twice for different transactions, resulting in `replacement fee too low` errors

## The Solution
<!--- Describe the changes you made at a high level -->
<!--- Leave comments on the source diff to draw attention to important low-level specifics -->
- Track nonce within the `ethService` class
