### PR TITLE
Handle event where nonce is expired and tx is not confirmed

### DIFF
--- a/modules/contracts/src.ts/services/ethService.ts
+++ b/modules/contracts/src.ts/services/ethService.ts
@@ -358,6 +358,7 @@ export class EthereumChainService extends EthereumChainReader implements IVector
     // in this data with the already-existing store record of the tx.
     let responses: TransactionResponse[] = [];
     let nonce: number | undefined;
+    let nonceExpired: boolean = false;
     let receipt: TransactionReceipt | undefined;
     let gasPrice: BigNumber;
 
@@ -456,6 +457,7 @@ export class EthereumChainService extends EthereumChainReader implements IVector
               // Another ethers message that we could potentially be getting back.
               error.message.includes("There is another transaction with same nonce in the queue."))
           ) {
+            nonceExpired = true;
             this.log.info(
               { method, methodId, channelAddress, reason, nonce, error: error.message },
               "Nonce already used: proceeding to check for confirmation in previous transactions.",
@@ -479,6 +481,23 @@ export class EthereumChainService extends EthereumChainReader implements IVector
       } catch (e) {
         // Check if the error was a confirmation timeout.
         if (e.message === ChainError.reasons.ConfirmationTimeout) {
+          if (nonceExpired) {
+            const error = new ChainError(ChainError.reasons.NonceExpired, {
+              methodId,
+              method,
+            });
+            await this.handleTxFail(
+              onchainTransactionId,
+              method,
+              methodId,
+              channelAddress,
+              reason,
+              receipt,
+              error,
+              "Nonce expired and could not confirm tx",
+            );
+            return Result.fail(error);
+          }
           // Scale up gas by percentage as specified by GAS_BUMP_PERCENT.
           // From ethers docs:
           // Generally, the new gas price should be about 50% + 1 wei more, so if a gas price

--- a/modules/types/src/chain.ts
+++ b/modules/types/src/chain.ts
@@ -67,6 +67,7 @@ export class ChainError extends VectorError {
     TxReverted: "Transaction reverted on chain",
     MaxGasPriceReached: "Max gas price reached",
     ConfirmationTimeout: "Timed out waiting for confirmation.",
+    NonceExpired: "Failed to confirm a tx whose nonce had expired.",
   };
 
   // Errors you would see from trying to send a transaction, and


### PR DESCRIPTION
## The Problem
We currently aren't erroring out properly for this specific case where:

- nonce expires,
- we proceed to poll for receipt in waitForConfirmation
- we time out, leading us to
- bump the tx (even though the nonce has expired).
- 
Why are we unable to get a receipt in waitForConfirmation if the nonce is expired? Shouldn't that imply that the tx is mined, and there's no reason we should be unable to get the receipt? I don't know, because we're not erroring out properly in those cases. This is just a step to prevent unnecessary gas bumping on a dead tx.
<!--- Why is this change required? What problem does it solve? Bug fix or new feature? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## The Solution
<!--- Describe the changes you made at a high level -->
Using a flag, nonceExpired, if we get a timeout with the flag raised then we error out properly.
<!--- Leave comments on the source diff to draw attention to important low-level specifics -->
